### PR TITLE
Uses correct folder, and disables host name checking 

### DIFF
--- a/app/sftp/ftp_client.py
+++ b/app/sftp/ftp_client.py
@@ -9,5 +9,8 @@ class FtpClient():
         self.password = app.config.get('FTP_PASSWORD')
 
     def send_file(self, filename):
-        with pysftp.Connection(self.host, username=self.username, password=self.password) as sftp:
+        cnopts = pysftp.CnOpts()
+        cnopts.hostkeys = None
+        with pysftp.Connection(self.host, username=self.username, password=self.password, cnopts=cnopts) as sftp:
+            sftp.chdir('notify')
             sftp.put(filename)


### PR DESCRIPTION
chdir to notify before sending file.

Also disables hostname checking. DVLA is IP Restricted and password protected. Having trouble getting the sftp library to find the hostkeys, and when boxes recycle it may break until ssh connection made which is problematic for an autoscaling group. So disabled for now.