### PR TITLE
Create task to send files to dvla

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+test_results.xml
+
 version.py
 
 cache/*

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -30,7 +30,7 @@ def create_app():
 
     notify_celery.init_app(application)
     statsd_client.init_app(application)
-    ftp_client.init_app(application)
+    ftp_client.init_app(application, statsd_client)
 
     from app.status.status import status_blueprint
     from app.sender.sender import sender_blueprint

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -1,5 +1,6 @@
 from app import notify_celery
 from flask import current_app
+from boto3 import resource
 
 
 @notify_celery.task(name="test")

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -1,4 +1,4 @@
-from app import notify_celery
+from app import notify_celery, ftp_client
 from flask import current_app
 from boto3 import resource
 from app.files.file_utils import (
@@ -21,6 +21,6 @@ def send_files_to_dvla(jobs_ids):
     ensure_local_file_directory()
     for job_id in jobs_ids:
         get_file_from_s3(current_app.config['DVLA_UPLOAD_BUCKET_NAME'], job_id)
-    concat_files()
-    # # ftp file
+    dvla_file = concat_files()
+    ftp_client.send_file("{}/{}".format(current_app.config['LOCAL_FILE_STORAGE_PATH'], dvla_file))
     remove_local_file_directory()

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -5,3 +5,10 @@ from flask import current_app
 @notify_celery.task(name="test")
 def test():
     current_app.logger.info("running task")
+
+
+@notify_celery.task(name="send-files-to-dvla")
+def send_files_to_dvla(bucket_name, jobs_ids):
+    current_app.logger.info("running task")
+    current_app.logger.info("Bucket name {}".format(bucket_name))
+    current_app.logger.info("Jobs {}".format(tuple(jobs_ids)))

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -18,9 +18,11 @@ def test():
 @notify_celery.task(name="send-files-to-dvla")
 @statsd(namespace="tasks")
 def send_files_to_dvla(jobs_ids):
-    ensure_local_file_directory()
-    for job_id in jobs_ids:
-        get_file_from_s3(current_app.config['DVLA_UPLOAD_BUCKET_NAME'], job_id)
-    dvla_file = concat_files()
-    ftp_client.send_file("{}/{}".format(current_app.config['LOCAL_FILE_STORAGE_PATH'], dvla_file))
-    remove_local_file_directory()
+    try:
+        ensure_local_file_directory()
+        for job_id in jobs_ids:
+            get_file_from_s3(current_app.config['DVLA_UPLOAD_BUCKET_NAME'], job_id)
+        dvla_file = concat_files()
+        ftp_client.send_file("{}/{}".format(current_app.config['LOCAL_FILE_STORAGE_PATH'], dvla_file))
+    finally:
+        remove_local_file_directory()

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -1,6 +1,13 @@
 from app import notify_celery
 from flask import current_app
 from boto3 import resource
+from app.files.file_utils import (
+    get_file_from_s3,
+    remove_local_file_directory,
+    concat_files,
+    ensure_local_file_directory
+)
+from app.statsd_decorators import statsd
 
 
 @notify_celery.task(name="test")
@@ -9,7 +16,11 @@ def test():
 
 
 @notify_celery.task(name="send-files-to-dvla")
-def send_files_to_dvla(bucket_name, jobs_ids):
-    current_app.logger.info("running task")
-    current_app.logger.info("Bucket name {}".format(bucket_name))
-    current_app.logger.info("Jobs {}".format(tuple(jobs_ids)))
+@statsd(namespace="tasks")
+def send_files_to_dvla(jobs_ids):
+    ensure_local_file_directory()
+    for job_id in jobs_ids:
+        get_file_from_s3(current_app.config['DVLA_UPLOAD_BUCKET_NAME'], job_id)
+    concat_files()
+    # # ftp file
+    remove_local_file_directory()

--- a/app/config.py
+++ b/app/config.py
@@ -54,6 +54,7 @@ class Config(object):
     STATSD_HOST = "statsd.hostedgraphite.com"
     STATSD_PORT = 8125
 
+    LOCAL_FILE_STORAGE_PATH = "~/dvla-file-storage"
 
 ######################
 # Config overrides ###
@@ -74,6 +75,7 @@ class Test(Config):
     STATSD_ENABLED = True
     STATSD_HOST = "localhost"
     STATSD_PORT = 1000
+    LOCAL_FILE_STORAGE_PATH = "/tmp/dvla-file-storage"
 
 
 class Preview(Config):

--- a/app/config.py
+++ b/app/config.py
@@ -42,7 +42,7 @@ class Config(object):
     CELERYBEAT_SCHEDULE = {
         'run-scheduled-jobs': {
             'task': 'test',
-            'schedule': crontab(minute=1),
+            'schedule': crontab(minute=30),
             'options': {'queue': 'process-ftp'}
         },
     }

--- a/app/config.py
+++ b/app/config.py
@@ -56,6 +56,9 @@ class Config(object):
 
     LOCAL_FILE_STORAGE_PATH = "~/dvla-file-storage"
 
+    DVLA_UPLOAD_BUCKET_NAME = "{}-dvla-file-per-job".format(os.getenv('NOTIFY_ENVIRONMENT'))
+
+
 ######################
 # Config overrides ###
 ######################
@@ -66,6 +69,7 @@ class Development(Config):
     NOTIFY_ENVIRONMENT = 'development'
     NOTIFICATION_QUEUE_PREFIX = 'development'
     DEBUG = True
+    LOCAL_FILE_STORAGE_PATH = "/tmp/dvla-file-storage"
 
 
 class Test(Config):

--- a/app/files/file_utils.py
+++ b/app/files/file_utils.py
@@ -2,6 +2,7 @@ import os
 from flask import current_app
 from datetime import datetime
 import shutil
+import boto3
 
 
 def dvla_file_name_for_concatanted_file():
@@ -12,8 +13,11 @@ def job_file_name_for_job(job_id):
     return "{}-dvla-job.text".format(job_id)
 
 
-def get_file_from_s3():
-    pass
+def get_file_from_s3(bucket_name, job_id):
+    s3 = boto3.client('s3')
+    filename = job_file_name_for_job(job_id)
+    with open("{}/{}".format(current_app.config['LOCAL_FILE_STORAGE_PATH'], filename), 'wb') as job_file:
+        s3.download_fileobj(bucket_name, filename, job_file)
 
 
 def concat_files():
@@ -28,8 +32,15 @@ def concat_files():
 
 
 def ensure_local_file_directory():
-    return os.path.exists(current_app.config['LOCAL_FILE_STORAGE_PATH'])
+    if not os.path.exists(current_app.config['LOCAL_FILE_STORAGE_PATH']):
+        create_local_file_directory()
 
 
 def create_local_file_directory():
-    return os.makedirs(current_app.config['LOCAL_FILE_STORAGE_PATH'])
+    if not os.path.exists(current_app.config['LOCAL_FILE_STORAGE_PATH']):
+        return os.makedirs(current_app.config['LOCAL_FILE_STORAGE_PATH'])
+
+
+def remove_local_file_directory():
+    if os.path.exists(current_app.config['LOCAL_FILE_STORAGE_PATH']):
+        shutil.rmtree(current_app.config['LOCAL_FILE_STORAGE_PATH'], ignore_errors=False)

--- a/app/files/file_utils.py
+++ b/app/files/file_utils.py
@@ -26,8 +26,10 @@ def concat_files():
 
     if len(all_files) > 0:
         with open("{}/{}".format(current_app.config['LOCAL_FILE_STORAGE_PATH'], dvla_filename), 'w+') as dvla_file:
+            current_app.logger.info("making {}".format(dvla_file.name))
             for job_file in all_files:
                 with open("{}/{}".format(current_app.config['LOCAL_FILE_STORAGE_PATH'], job_file), 'r') as readfile:
+                    current_app.logger.info("concatenating {}".format(job_file))
                     shutil.copyfileobj(readfile, dvla_file)
 
 
@@ -38,7 +40,7 @@ def ensure_local_file_directory():
 
 def create_local_file_directory():
     if not os.path.exists(current_app.config['LOCAL_FILE_STORAGE_PATH']):
-        return os.makedirs(current_app.config['LOCAL_FILE_STORAGE_PATH'])
+        os.makedirs(current_app.config['LOCAL_FILE_STORAGE_PATH'])
 
 
 def remove_local_file_directory():

--- a/app/files/file_utils.py
+++ b/app/files/file_utils.py
@@ -31,6 +31,7 @@ def concat_files():
                 with open("{}/{}".format(current_app.config['LOCAL_FILE_STORAGE_PATH'], job_file), 'r') as readfile:
                     current_app.logger.info("concatenating {}".format(job_file))
                     shutil.copyfileobj(readfile, dvla_file)
+    return dvla_filename
 
 
 def ensure_local_file_directory():

--- a/app/files/file_utils.py
+++ b/app/files/file_utils.py
@@ -1,0 +1,35 @@
+import os
+from flask import current_app
+from datetime import datetime
+import shutil
+
+
+def dvla_file_name_for_concatanted_file():
+    return "Notify-{}-rq.txt".format(datetime.utcnow().strftime("%Y%m%d%H%M"))
+
+
+def job_file_name_for_job(job_id):
+    return "{}-dvla-job.text".format(job_id)
+
+
+def get_file_from_s3():
+    pass
+
+
+def concat_files():
+    dvla_filename = dvla_file_name_for_concatanted_file()
+    all_files = os.listdir(current_app.config['LOCAL_FILE_STORAGE_PATH'])
+
+    if len(all_files) > 0:
+        with open("{}/{}".format(current_app.config['LOCAL_FILE_STORAGE_PATH'], dvla_filename), 'w+') as dvla_file:
+            for job_file in all_files:
+                with open("{}/{}".format(current_app.config['LOCAL_FILE_STORAGE_PATH'], job_file), 'r') as readfile:
+                    shutil.copyfileobj(readfile, dvla_file)
+
+
+def ensure_local_file_directory():
+    return os.path.exists(current_app.config['LOCAL_FILE_STORAGE_PATH'])
+
+
+def create_local_file_directory():
+    return os.makedirs(current_app.config['LOCAL_FILE_STORAGE_PATH'])

--- a/app/sender/sender.py
+++ b/app/sender/sender.py
@@ -6,6 +6,7 @@ from flask import (
 )
 
 from app import ftp_client
+from app.celery.tasks import send_files_to_dvla
 
 sender_blueprint = Blueprint('send', __name__)
 
@@ -15,3 +16,9 @@ def send_file():
     filename = request.args.get('filename')
     ftp_client.send_file("/tmp/" + filename)
     return jsonify(result="success", filename=filename), 200
+
+
+@sender_blueprint.route('/test-queue', methods=['GET'])
+def test_queue():
+    send_files_to_dvla.apply_async(["BUCKET", ["1", "2", "3", "4", "5"]], queue="process-ftp")
+    return jsonify(result="success"), 200

--- a/app/sender/sender.py
+++ b/app/sender/sender.py
@@ -25,12 +25,6 @@ def send_file():
     return jsonify(result="success", filename=filename), 200
 
 
-@sender_blueprint.route('/test-queue', methods=['GET'])
-def test_queue():
-    send_files_to_dvla.apply_async(["BUCKET", ["1", "2", "3", "4", "5"]], queue="process-ftp")
-    return jsonify(result="success"), 200
-
-
 @sender_blueprint.route('/test-s3', methods=['GET'])
 def test_s3():
     request.args.getlist('job_id')

--- a/app/sftp/ftp_client.py
+++ b/app/sftp/ftp_client.py
@@ -1,16 +1,32 @@
 import pysftp
 from flask import current_app
+import os
+from monotonic import monotonic
 
 
 class FtpClient():
-    def init_app(self, app):
+    def init_app(self, app, statsd_client):
         self.host = app.config.get('FTP_HOST')
         self.username = app.config.get('FTP_USERNAME')
         self.password = app.config.get('FTP_PASSWORD')
+        self.statsd_client = statsd_client
+
 
     def send_file(self, filename):
         cnopts = pysftp.CnOpts()
         cnopts.hostkeys = None
+        current_app.logger.info("opening connection to {}".format(self.host))
         with pysftp.Connection(self.host, username=self.username, password=self.password, cnopts=cnopts) as sftp:
             sftp.chdir('notify')
+            current_app.logger.info("uploading {}".format(filename))
+
+            start_time = monotonic()
             sftp.put(filename)
+            self.statsd_client.timing("ftp-client.upload-time", monotonic() - start_time)
+
+            filename_without_path = os.path.split(filename)[1]
+            if filename_without_path in sftp.listdir():
+                current_app.logger.info("File {} successfully uploaded".format(filename_without_path))
+            else:
+                current_app.debug(remote_files)
+                raise Exception("File {} not uploaded".format(filename_without_path))

--- a/app/sftp/ftp_client.py
+++ b/app/sftp/ftp_client.py
@@ -11,7 +11,6 @@ class FtpClient():
         self.password = app.config.get('FTP_PASSWORD')
         self.statsd_client = statsd_client
 
-
     def send_file(self, filename):
         cnopts = pysftp.CnOpts()
         cnopts.hostkeys = None

--- a/app/statsd_decorators.py
+++ b/app/statsd_decorators.py
@@ -1,0 +1,40 @@
+import functools
+
+from app import statsd_client
+from flask import current_app
+from monotonic import monotonic
+
+
+def statsd(namespace):
+    def time_function(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            start_time = monotonic()
+            try:
+                res = func(*args, **kwargs)
+                elapsed_time = monotonic() - start_time
+                statsd_client.incr('{namespace}.{func}'.format(
+                    namespace=namespace, func=func.__name__)
+                )
+                statsd_client.timing('{namespace}.{func}'.format(
+                    namespace=namespace, func=func.__name__), elapsed_time
+                )
+
+            except Exception as e:
+                current_app.logger.error(
+                    "{namespace} call {func} failed".format(
+                        namespace=namespace, func=func.__name__
+                    )
+                )
+                raise e
+            else:
+                current_app.logger.info(
+                    "{namespace} call {func} took {time}".format(
+                        namespace=namespace, func=func.__name__, time="{0:.4f}".format(elapsed_time)
+                    )
+                )
+                return res
+        wrapper.__wrapped__.__name__ = func.__name__
+        return wrapper
+
+    return time_function

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 pycodestyle==2.3.1
-pytest==3.0.1
-pytest-mock==1.2
+pytest==3.0.7
+pytest-mock==1.6
 pytest-cov==2.3.1
 coveralls==1.1
 moto==0.4.25

--- a/scripts/stop_celery.py
+++ b/scripts/stop_celery.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""
+
+Scipt used to stop celery in AWS environments.
+This is used from upstart to issue a TERM signal to the master celery process.
+
+This will then allow the worker threads to stop, after completing
+whatever tasks that are in flight.
+
+Note the script blocks for up to 15minutes, which is long enough to allow our
+longest possible task to complete. If it can return quicker it will.
+
+Usage:
+    ./stop_celery.py <celery_pid_file>
+
+Example:
+    ./stop_celery.py /tmp/celery.pid
+"""
+
+import os
+from docopt import docopt
+import re
+import subprocess
+from time import sleep
+
+
+def strip_white_space(from_this):
+    return re.sub(r'\s+', '', from_this)
+
+
+def get_pid_from_file(filename):
+    """
+    Open the file which MUST contain only the PID of the master celery process.
+    This is written to disk by the start celery command issued by upstart
+    """
+    with open(filename) as f:
+        celery_pid = f.read()
+    return strip_white_space(celery_pid)
+
+
+def issue_term_signal_to_pid(pid, celery_pid_file):
+    """
+    Issues a TERM signal (15) to the master celery process.
+
+    This method attempts to print out any response from this subprocess call. However this call is generally silent.
+    """
+    print("Trying to stop ", celery_pid_file)
+    result = subprocess.Popen(['kill', '-15', pid], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    for line in result.stdout.readlines():
+        print(line.rstrip())
+    for line in result.stderr.readlines():
+        print(line.rstrip())
+
+
+def pid_still_running(pid):
+    """
+    uses the proc filesystem to identify if the celery master pid is still around.
+
+    Once the process stops this file no longer exists. Slim possibilty of a race condition here.
+    """
+    return os.path.exists("/proc/" + pid)
+
+
+if __name__ == "__main__":
+    arguments = docopt(__doc__)
+    celery_pid_file = arguments['<celery_pid_file>']
+
+    celery_pid = get_pid_from_file(celery_pid_file)
+
+    issue_term_signal_to_pid(celery_pid, celery_pid_file)
+
+    """
+    Blocking loop to check for the still running process.
+    5 seconds between loops
+    180 loops
+    Maximum block time of 900 seconds (15 minutes)
+    """
+    iteration = 0
+    while pid_still_running(celery_pid) and iteration < 180:
+        print("[", celery_pid_file, "] waited for ", iteration * 5, " secs")
+        sleep(5)
+        iteration += 1

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -1,3 +1,22 @@
+from app.celery.tasks import send_files_to_dvla
+import app
+from unittest.mock import call
 
-def test_task():
-    assert 1 == 1
+
+def test_should_call_get_file_for_each_job_id(client, mocker):
+    mocker.patch('app.celery.tasks.ensure_local_file_directory')
+    mocker.patch('app.celery.tasks.get_file_from_s3')
+    mocker.patch('app.celery.tasks.concat_files')
+    mocker.patch('app.celery.tasks.remove_local_file_directory')
+
+    send_files_to_dvla(["1", "2", "3"])
+
+    app.celery.tasks.ensure_local_file_directory.assert_called_once_with()
+    assert app.celery.tasks.get_file_from_s3.call_args_list == [
+        call("test-dvla-file-per-job", "1"),
+        call("test-dvla-file-per-job", "2"),
+        call("test-dvla-file-per-job", "3")
+    ]
+    app.celery.tasks.concat_files.assert_called_once_with()
+    app.celery.tasks.remove_local_file_directory.assert_called_once_with()
+

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -1,0 +1,3 @@
+
+def test_task():
+    assert 1 == 1

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -1,22 +1,25 @@
 from app.celery.tasks import send_files_to_dvla
 import app
 from unittest.mock import call
+from freezegun import freeze_time
 
 
 def test_should_call_get_file_for_each_job_id(client, mocker):
-    mocker.patch('app.celery.tasks.ensure_local_file_directory')
-    mocker.patch('app.celery.tasks.get_file_from_s3')
-    mocker.patch('app.celery.tasks.concat_files')
-    mocker.patch('app.celery.tasks.remove_local_file_directory')
+    with freeze_time('2016-01-01T17:00:00'):
+        mocker.patch('app.celery.tasks.ensure_local_file_directory')
+        mocker.patch('app.celery.tasks.get_file_from_s3')
+        mocker.patch('app.celery.tasks.concat_files', return_value="DVLA-FILE")
+        mocker.patch('app.celery.tasks.remove_local_file_directory')
+        mocker.patch('app.celery.tasks.ftp_client.send_file')
 
-    send_files_to_dvla(["1", "2", "3"])
+        send_files_to_dvla(["1", "2", "3"])
 
-    app.celery.tasks.ensure_local_file_directory.assert_called_once_with()
-    assert app.celery.tasks.get_file_from_s3.call_args_list == [
-        call("test-dvla-file-per-job", "1"),
-        call("test-dvla-file-per-job", "2"),
-        call("test-dvla-file-per-job", "3")
-    ]
-    app.celery.tasks.concat_files.assert_called_once_with()
-    app.celery.tasks.remove_local_file_directory.assert_called_once_with()
-
+        app.celery.tasks.ensure_local_file_directory.assert_called_once_with()
+        assert app.celery.tasks.get_file_from_s3.call_args_list == [
+            call("test-dvla-file-per-job", "1"),
+            call("test-dvla-file-per-job", "2"),
+            call("test-dvla-file-per-job", "3")
+        ]
+        app.celery.tasks.concat_files.assert_called_once_with()
+        app.celery.tasks.ftp_client.send_file.assert_called_once_with("/tmp/dvla-file-storage/DVLA-FILE")
+        app.celery.tasks.remove_local_file_directory.assert_called_once_with()

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -2,6 +2,7 @@ from app.celery.tasks import send_files_to_dvla
 import app
 from unittest.mock import call
 from freezegun import freeze_time
+import pytest
 
 
 def test_should_call_get_file_for_each_job_id(client, mocker):
@@ -23,3 +24,18 @@ def test_should_call_get_file_for_each_job_id(client, mocker):
         app.celery.tasks.concat_files.assert_called_once_with()
         app.celery.tasks.ftp_client.send_file.assert_called_once_with("/tmp/dvla-file-storage/DVLA-FILE")
         app.celery.tasks.remove_local_file_directory.assert_called_once_with()
+
+
+def test_should_call_remove_local_files_in_event_of_exception(client, mocker):
+    with freeze_time('2016-01-01T17:00:00'):
+        mocker.patch('app.celery.tasks.ensure_local_file_directory')
+        mocker.patch('app.celery.tasks.get_file_from_s3')
+        mocker.patch('app.celery.tasks.concat_files', return_value="DVLA-FILE")
+        mocker.patch('app.celery.tasks.remove_local_file_directory')
+        mocker.patch('app.celery.tasks.ftp_client.send_file', side_effect=Exception("FAILED TO SEND FILE"))
+
+        with pytest.raises(Exception) as excinfo:
+            send_files_to_dvla(["1"])
+            app.celery.tasks.ftp_client.send_file.assert_called_once_with("/tmp/dvla-file-storage/DVLA-FILE")
+            assert 'FAILED TO SEND FILE' in str(excinfo.value)
+            app.celery.tasks.remove_local_file_directory.assert_called_once_with()

--- a/tests/app/file_utils/test_file_utils.py
+++ b/tests/app/file_utils/test_file_utils.py
@@ -7,7 +7,8 @@ from app.files.file_utils import (
     ensure_local_file_directory,
     concat_files,
     job_file_name_for_job,
-    dvla_file_name_for_concatanted_file
+    dvla_file_name_for_concatanted_file,
+    remove_local_file_directory
 )
 
 
@@ -21,15 +22,39 @@ def test_should_make_job_filename_from_job_id():
 
 
 def test_should_create_directory_for_dval_files(client):
-    assert not ensure_local_file_directory()
-    create_local_file_directory()
-    assert ensure_local_file_directory()
+    assert not os.path.exists(current_app.config['LOCAL_FILE_STORAGE_PATH'])
+    ensure_local_file_directory()
+    assert os.path.exists(current_app.config['LOCAL_FILE_STORAGE_PATH'])
+
+
+def test_should_delete_all_files(client):
+    ensure_local_file_directory()
+    files = ['file-1', 'file-2', 'file-3']
+    ensure_local_file_directory()
+    for file in files:
+        with open("{}/{}".format(current_app.config['LOCAL_FILE_STORAGE_PATH'], file), 'w+') as test_file:
+            test_file.write(file + "\n")
+
+    assert len(os.listdir(current_app.config['LOCAL_FILE_STORAGE_PATH'])) == 3
+    remove_local_file_directory()
+    assert not os.path.exists(current_app.config['LOCAL_FILE_STORAGE_PATH'])
+
+
+def test_should_delete_all_files_should_handle_case_where_folder_doesnt_exist(client):
+    remove_local_file_directory()
+    assert not os.path.exists(current_app.config['LOCAL_FILE_STORAGE_PATH'])
+
+
+def test_should_delete_all_files_should_handle_case_where_folder_has_no_files(client):
+    ensure_local_file_directory()
+    remove_local_file_directory()
+    assert not os.path.exists(current_app.config['LOCAL_FILE_STORAGE_PATH'])
 
 
 def test_should_create_single_file_from_all_files_in_directory(client):
     with freeze_time('2016-01-01T17:00:00'):
         files = ['file-1', 'file-2', 'file-3']
-        create_local_file_directory()
+        ensure_local_file_directory()
         for file in files:
             with open("{}/{}".format(current_app.config['LOCAL_FILE_STORAGE_PATH'], file), 'w+') as test_file:
                 test_file.write(file + "\n")
@@ -47,6 +72,6 @@ def test_should_create_single_file_from_all_files_in_directory(client):
 
 def test_should_leave_an_empty_directory_if_no_files_in_directory(client):
     with freeze_time('2016-01-01T17:00:00'):
-        create_local_file_directory()
+        ensure_local_file_directory()
         concat_files()
         assert len(os.listdir(current_app.config['LOCAL_FILE_STORAGE_PATH'])) == 0

--- a/tests/app/file_utils/test_file_utils.py
+++ b/tests/app/file_utils/test_file_utils.py
@@ -1,0 +1,52 @@
+import os
+from flask import current_app
+from freezegun import freeze_time
+
+from app.files.file_utils import (
+    create_local_file_directory,
+    ensure_local_file_directory,
+    concat_files,
+    job_file_name_for_job,
+    dvla_file_name_for_concatanted_file
+)
+
+
+def test_dvla_file_name_for_concatanted_file():
+    with freeze_time('2016-01-01T17:00:00'):
+        assert dvla_file_name_for_concatanted_file() == "Notify-201601011700-rq.txt"
+
+
+def test_should_make_job_filename_from_job_id():
+    assert job_file_name_for_job("1234") == "1234-dvla-job.text"
+
+
+def test_should_create_directory_for_dval_files(client):
+    assert not ensure_local_file_directory()
+    create_local_file_directory()
+    assert ensure_local_file_directory()
+
+
+def test_should_create_single_file_from_all_files_in_directory(client):
+    with freeze_time('2016-01-01T17:00:00'):
+        files = ['file-1', 'file-2', 'file-3']
+        create_local_file_directory()
+        for file in files:
+            with open("{}/{}".format(current_app.config['LOCAL_FILE_STORAGE_PATH'], file), 'w+') as test_file:
+                test_file.write(file + "\n")
+
+        concat_files()
+
+        with open(
+                "{}/Notify-201601011700-rq.txt".format(current_app.config['LOCAL_FILE_STORAGE_PATH'])
+        ) as concat_file:
+            lines = concat_file.readlines()
+            assert lines[0].rstrip() == 'file-1'
+            assert lines[1].rstrip() == 'file-2'
+            assert lines[2].rstrip() == 'file-3'
+
+
+def test_should_leave_an_empty_directory_if_no_files_in_directory(client):
+    with freeze_time('2016-01-01T17:00:00'):
+        create_local_file_directory()
+        concat_files()
+        assert len(os.listdir(current_app.config['LOCAL_FILE_STORAGE_PATH'])) == 0

--- a/tests/app/file_utils/test_file_utils.py
+++ b/tests/app/file_utils/test_file_utils.py
@@ -66,10 +66,11 @@ def test_should_create_single_file_from_all_files_in_directory(client):
         with open(
                 "{}/Notify-201601011700-rq.txt".format(current_app.config['LOCAL_FILE_STORAGE_PATH'])
         ) as concat_file:
-            lines = concat_file.readlines()
-            assert lines[0].rstrip() == 'file-1'
-            assert lines[1].rstrip() == 'file-2'
-            assert lines[2].rstrip() == 'file-3'
+            lines = [line.rstrip() for line in concat_file.readlines()]
+            assert len(lines) == 3
+            assert 'file-1' in lines
+            assert 'file-2' in lines
+            assert 'file-3' in lines
 
 
 def test_should_leave_an_empty_directory_if_no_files_in_directory(client):

--- a/tests/app/file_utils/test_file_utils.py
+++ b/tests/app/file_utils/test_file_utils.py
@@ -59,7 +59,9 @@ def test_should_create_single_file_from_all_files_in_directory(client):
             with open("{}/{}".format(current_app.config['LOCAL_FILE_STORAGE_PATH'], file), 'w+') as test_file:
                 test_file.write(file + "\n")
 
-        concat_files()
+        filename = concat_files()
+
+        assert filename == "Notify-201601011700-rq.txt"
 
         with open(
                 "{}/Notify-201601011700-rq.txt".format(current_app.config['LOCAL_FILE_STORAGE_PATH'])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,9 @@
 import pytest
 from app import create_app
+import os
+from flask import current_app
+import shutil
+from app.files.file_utils import ensure_local_file_directory
 
 
 @pytest.fixture(scope='session')
@@ -18,3 +22,5 @@ def notify_ftp():
 def client(notify_ftp):
     with notify_ftp.test_request_context(), notify_ftp.test_client() as client:
         yield client
+        if ensure_local_file_directory():
+            shutil.rmtree(current_app.config['LOCAL_FILE_STORAGE_PATH'], ignore_errors=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,5 +22,5 @@ def notify_ftp():
 def client(notify_ftp):
     with notify_ftp.test_request_context(), notify_ftp.test_client() as client:
         yield client
-        if ensure_local_file_directory():
+        if os.path.exists(current_app.config['LOCAL_FILE_STORAGE_PATH']):
             shutil.rmtree(current_app.config['LOCAL_FILE_STORAGE_PATH'], ignore_errors=False)


### PR DESCRIPTION
Set up code for sending files to DVLA.

- A bunch of file util methods to name, move, delete and fetch from S3 letter files
- This will pull down all the files, identified by their job ID
- These files are concatenated together and renamed to be the DVLA shaped file.
- This is then FTP'd to the FTP server defined in the config.

- All local directories are created and deleted on each run.