### PR TITLE
Create a task to update the job and notifications once the DVLA file is sent

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -24,5 +24,8 @@ def send_files_to_dvla(jobs_ids):
             get_file_from_s3(current_app.config['DVLA_UPLOAD_BUCKET_NAME'], job_id)
         dvla_file = concat_files()
         ftp_client.send_file("{}/{}".format(current_app.config['LOCAL_FILE_STORAGE_PATH'], dvla_file))
+
+        for job_id in jobs_ids:
+            notify_celery.send_task(name="update-letter-job-to-sent", args=(job_id,), queue="notify")
     finally:
         remove_local_file_directory()

--- a/scripts/run_celery.sh
+++ b/scripts/run_celery.sh
@@ -3,5 +3,5 @@
 set -e
 
 source environment.sh
-celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency=1
+celery -A run_celery.notify_celery worker --pidfile="/tmp/celery-ftp.pid" --loglevel=INFO --concurrency=1
 

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -12,6 +12,7 @@ def test_should_call_get_file_for_each_job_id(client, mocker):
         mocker.patch('app.celery.tasks.concat_files', return_value="DVLA-FILE")
         mocker.patch('app.celery.tasks.remove_local_file_directory')
         mocker.patch('app.celery.tasks.ftp_client.send_file')
+        mocker.patch('app.notify_celery.send_task')
 
         send_files_to_dvla(["1", "2", "3"])
 
@@ -23,6 +24,11 @@ def test_should_call_get_file_for_each_job_id(client, mocker):
         ]
         app.celery.tasks.concat_files.assert_called_once_with()
         app.celery.tasks.ftp_client.send_file.assert_called_once_with("/tmp/dvla-file-storage/DVLA-FILE")
+        assert app.notify_celery.send_task.call_args_list == [
+            call(name="update-letter-job-to-sent", args=("1",), queue="notify"),
+            call(name="update-letter-job-to-sent", args=("2",), queue="notify"),
+            call(name="update-letter-job-to-sent", args=("3",), queue="notify")
+        ]
         app.celery.tasks.remove_local_file_directory.assert_called_once_with()
 
 
@@ -33,9 +39,11 @@ def test_should_call_remove_local_files_in_event_of_exception(client, mocker):
         mocker.patch('app.celery.tasks.concat_files', return_value="DVLA-FILE")
         mocker.patch('app.celery.tasks.remove_local_file_directory')
         mocker.patch('app.celery.tasks.ftp_client.send_file', side_effect=Exception("FAILED TO SEND FILE"))
+        mocker.patch('app.notify_celery.send_task')
 
         with pytest.raises(Exception) as excinfo:
             send_files_to_dvla(["1"])
             app.celery.tasks.ftp_client.send_file.assert_called_once_with("/tmp/dvla-file-storage/DVLA-FILE")
             assert 'FAILED TO SEND FILE' in str(excinfo.value)
+            app.notify_celery.send_task.assert_not_called()
             app.celery.tasks.remove_local_file_directory.assert_called_once_with()


### PR DESCRIPTION
there is a task in the API code that updates a job and corresponding notifications to a "sent" status.

This change puts a task on the queue to trigger that task for each job that has been sent to DVLA.