### PR TITLE
As the API and FTP share a queue, we need to ensure that they use the…

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -31,7 +31,7 @@ class Config(object):
     BROKER_TRANSPORT_OPTIONS = {
         'region': AWS_REGION,
         'polling_interval': 1,
-        'visibility_timeout': 30,
+        'visibility_timeout': 14410,
         'queue_name_prefix': NOTIFICATION_QUEUE_PREFIX
     }
     CELERY_ENABLE_UTC = True,


### PR DESCRIPTION
… same timeout or celery gets confused and falls over when reading from the queue.