### PR TITLE
Only send if successful jobs

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -30,7 +30,8 @@ def send_files_to_dvla(jobs_ids):
         dvla_file, successful_jobs, failures = concat_files()
         failed_jobs += [job_id_from_filename(failed_file) for failed_file in failures]
 
-        ftp_client.send_file("{}/{}".format(current_app.config['LOCAL_FILE_STORAGE_PATH'], dvla_file))
+        if successful_jobs:
+            ftp_client.send_file("{}/{}".format(current_app.config['LOCAL_FILE_STORAGE_PATH'], dvla_file))
 
         for successful_job in successful_jobs:
             notify_celery.send_task(

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -226,14 +226,15 @@ def test_should_update_all_tasks_as_failed_if_ftp_fails(client, mocker):
 def test_should_not_try_and_send_a_file_if_all_jobs_failed(client, mocker):
     with freeze_time('2016-01-01T17:00:00'):
         def side_effect():
-            return \
-                "DVLA-FILE", \
-                [], \
+            return (
+                "DVLA-FILE",
+                [],
                 [
                     "0d0a0398-4c68-4c8d-9790-5d9632ecb1da",
                     "3872ce4a-8817-44b9-bca6-972ac6706b59",
                     "c278d13c-40cf-4091-ac88-3ef6eaeae4e8"
                 ]
+            )
 
         def failed_to_download(*args, **kwargs):
             return True

--- a/tests/app/celery/test_tasks.py
+++ b/tests/app/celery/test_tasks.py
@@ -257,4 +257,3 @@ def test_should_not_try_and_send_a_file_if_all_jobs_failed(client, mocker):
         ]
 
         assert not app.celery.tasks.ftp_client.send_file.called
-


### PR DESCRIPTION
Little check to only try and FTP a file if some of the jobs we are processing have been successfully concatendated.

In the offchance they all fail, we try and connect to DVLA and then there is no file to transfer, so we get an unnecessary error.