### PR TITLE
add cffi as separate req

### DIFF
--- a/scripts/aws_install_dependencies.sh
+++ b/scripts/aws_install_dependencies.sh
@@ -5,4 +5,6 @@ set -eo pipefail
 echo "Install dependencies"
 
 cd /home/notify-app/notifications-ftp;
+# had problems with crypto (required by pysftp) installing cffi, so trying to install it ourselves beforehand
+pip3 install cffi>=1.7
 pip3 install --find-links=wheelhouse -r /home/notify-app/notifications-ftp/requirements.txt

--- a/scripts/aws_install_dependencies.sh
+++ b/scripts/aws_install_dependencies.sh
@@ -6,5 +6,5 @@ echo "Install dependencies"
 
 cd /home/notify-app/notifications-ftp;
 # had problems with crypto (required by pysftp) installing cffi, so trying to install it ourselves beforehand
-pip3 install cffi>=1.7
+pip3 install cffi==1.7
 pip3 install --find-links=wheelhouse -r /home/notify-app/notifications-ftp/requirements.txt


### PR DESCRIPTION
separate to the main reqs so we can verify that it has installed. it should be installed by cryptography (a sub-dependency of pysftp), but for some reason that's coming up with errors, possibly related to https://github.com/shazow/urllib3/pull/385