### PR TITLE
Write to separate log files (by process id)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ celery==3.1.25
 monotonic==1.2
 boto3==1.4.4
 
-git+https://github.com/alphagov/notifications-utils.git@18.0.1#egg=notifications-utils==18.0.1
+git+https://github.com/alphagov/notifications-utils.git@20.0.0#egg=notifications-utils==20.0.0
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3


### PR DESCRIPTION
This brings in changes made to utils where we will now separate log files by process [1]

## Summary

Writing to the same log file from multiple python processes is
unsupported [1]. Since we run both the app and celery on this machine, we may have issues where both processes are trying to write to the same log file and can lose log output.

This adds the change to have a separate log file for celery and the app to avoid these issues.

[1] - https://github.com/alphagov/notifications-utils/pull/213