### PR TITLE
Fix import issue in celery

### DIFF
--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -1,4 +1,5 @@
 from celery import Celery, Task
+from flask import current_app
 
 
 class NotifyTask(Task):


### PR DESCRIPTION
Import current_app to fix below:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.4/dist-packages/celery/app/trace.py", line 253, in trace_task
    I, R, state, retval = on_error(task_request, exc, uuid)
  File "/usr/local/lib/python3.4/dist-packages/celery/app/trace.py", line 201, in on_error
    R = I.handle_error_state(task, eager=eager)
  File "/usr/local/lib/python3.4/dist-packages/celery/app/trace.py", line 85, in handle_error_state
    }[self.state](task, store_errors=store_errors)
  File "/usr/local/lib/python3.4/dist-packages/celery/app/trace.py", line 120, in handle_failure
    task.on_failure(exc, req.id, req.args, req.kwargs, einfo)
  File "/home/notify-app/notifications-ftp/app/celery/celery.py", line 9, in on_failure
    current_app.logger.exception('Celery task failed')
NameError: name 'current_app' is not defined
```