### PR TITLE
Rename parameter to local_file instead of local_filename

### DIFF
--- a/app/sender/sender.py
+++ b/app/sender/sender.py
@@ -14,7 +14,7 @@ sender_blueprint = Blueprint('send', __name__)
 @sender_blueprint.route('/send', methods=['POST'])
 def send_file():
     filename = request.args.get('filename')
-    ftp_client.send_file(local_filename="/tmp/" + filename)
+    ftp_client.send_file(local_file="/tmp/" + filename)
     return jsonify(result="success", filename=filename), 200
 
 

--- a/tests/app/sender/test_sender.py
+++ b/tests/app/sender/test_sender.py
@@ -12,7 +12,7 @@ def test_should_send_correct_file(client, mocker):
         response = client.post('/send?filename=test.txt')
     json_resp = json.loads(response.get_data(as_text=True))
     app.ftp_client.send_file.assert_called_with(
-        local_filename="/tmp/test.txt",
+        local_file="/tmp/test.txt",
     )
     assert response.status_code == 200
     assert json_resp['filename'] == "test.txt"


### PR DESCRIPTION
send_file won't work unless the parameter is renamed