### PR TITLE
Allow ftp client to process zip files

### DIFF
--- a/app/files/file_utils.py
+++ b/app/files/file_utils.py
@@ -11,18 +11,28 @@ import boto3
 
 
 DVLA_FILENAME_FORMAT = 'Notify-%Y%m%d%H%M-rq.txt'
+DVLA_ZIP_FILENAME_FORMAT = 'Notify.%Y%m%d%H%M.zip'
 
 
-def get_dvla_file_name(dt=None):
+def _get_dvla_format(file_ext='.txt'):
+    if file_ext and file_ext.lower() == '.zip':
+        dvla_format = DVLA_ZIP_FILENAME_FORMAT
+    else:
+        dvla_format = DVLA_FILENAME_FORMAT
+    return dvla_format
+
+
+def get_dvla_file_name(dt=None, file_ext='.txt'):
     dt = dt or datetime.utcnow()
-    return dt.strftime(DVLA_FILENAME_FORMAT)
+    return dt.strftime(_get_dvla_format(file_ext))
 
 
 def get_new_dvla_filename(old_filename):
+    file_ext = os.path.splitext(old_filename)[1]
     # increment the time by one minute
-    old_datetime = datetime.strptime(old_filename, DVLA_FILENAME_FORMAT)
+    old_datetime = datetime.strptime(old_filename, _get_dvla_format(file_ext))
 
-    return get_dvla_file_name(dt=old_datetime + timedelta(minutes=1))
+    return get_dvla_file_name(dt=old_datetime + timedelta(minutes=1), file_ext=file_ext)
 
 
 def job_file_name_for_job(job_id):

--- a/app/sftp/ftp_client.py
+++ b/app/sftp/ftp_client.py
@@ -40,7 +40,8 @@ def upload_file(sftp, local_file, statsd_client):
 
     start_time = monotonic()
 
-    remote_filename = get_dvla_file_name()
+    file_ext = os.path.splitext(local_file)[1]
+    remote_filename = get_dvla_file_name(file_ext=file_ext)
 
     if sftp.exists('{}/{}'.format(sftp.pwd, remote_filename)):
         # increment the time in the filename by one minute - if there's ALSO a file with that name, then

--- a/tests/app/file_utils/test_file_utils.py
+++ b/tests/app/file_utils/test_file_utils.py
@@ -69,14 +69,23 @@ def test_get_api_from_s3_should_get_correct_file_to_download(local_api_dir, mock
     )
 
 
-def test_get_dvla_file_name():
+@pytest.mark.parametrize('file_ext,remote_filename', [
+    (None, 'Notify-201601011700-rq.txt'),
+    ('.txt', 'Notify-201601011700-rq.txt'),
+    ('.zip', 'Notify.201601011700.zip')
+])
+def test_get_dvla_file_name(file_ext, remote_filename):
     with freeze_time('2016-01-01T17:00:00'):
-        assert get_dvla_file_name() == 'Notify-201601011700-rq.txt'
+        assert get_dvla_file_name(file_ext=file_ext) == remote_filename
 
 
-def test_get_new_dvla_file_name():
+@pytest.mark.parametrize('old_filename,remote_filename', [
+    ('Notify-201601011759-rq.txt', 'Notify-201601011800-rq.txt'),
+    ('Notify.201601011759.zip', 'Notify.201601011800.zip')
+])
+def test_get_new_dvla_file_name(old_filename, remote_filename):
     # increment from 17:59 to 18:00
-    assert get_new_dvla_filename('Notify-201601011759-rq.txt') == 'Notify-201601011800-rq.txt'
+    assert get_new_dvla_filename(old_filename) == remote_filename
 
 
 def test_should_make_job_filename_from_job_id():

--- a/tests/app/sftp/test_ftp_client.py
+++ b/tests/app/sftp/test_ftp_client.py
@@ -7,9 +7,11 @@ from app.sftp.ftp_client import upload_file, FtpException
 
 
 @freeze_time('2016-01-01T17:00:00')
-def test_send_file_generates_remote_filename():
-    local_file = '/tmp/something/foo.txt'
-    remote_filename = 'Notify-201601011700-rq.txt'
+@pytest.mark.parametrize('local_file,remote_filename', [
+    ('/tmp/something/foo.txt', 'Notify-201601011700-rq.txt'),
+    ('/tmp/something/foo.zip', 'Notify.201601011700.zip')
+])
+def test_send_file_generates_remote_filename(local_file, remote_filename):
     sftp = Mock(
         pwd='~/notify',
         exists=Mock(return_value=False),
@@ -23,9 +25,11 @@ def test_send_file_generates_remote_filename():
 
 
 @freeze_time('2016-01-01T17:00:00')
-def test_send_file_increments_filename_if_exists():
-    local_file = '/tmp/something/foo.txt'
-    remote_filename = 'Notify-201601011701-rq.txt'
+@pytest.mark.parametrize('local_file,remote_filename', [
+    ('/tmp/something/foo.txt', 'Notify-201601011701-rq.txt'),
+    ('/tmp/something/foo.zip', 'Notify.201601011701.zip')
+])
+def test_send_file_increments_filename_if_exists(local_file, remote_filename):
     sftp = Mock(
         pwd='~/notify',
         exists=Mock(return_value=True),


### PR DESCRIPTION
This PR will allow testing of transfer of zip files to dvla without interrupting the existing ftp service

Filename format of new zip files should be

DVLA: NOTIFY.20170823160812.ZIP

where numbers represent date of the zip file - YYYYMMDDHHMM