### PR TITLE
make sure we read files with utf-8 encoding

### DIFF
--- a/app/files/file_utils.py
+++ b/app/files/file_utils.py
@@ -91,7 +91,7 @@ def _remove_local_file_directory(subfolder):
 
 
 def get_notification_references(filename):
-    with (Path(current_app.config['LOCAL_FILE_STORAGE_PATH']) / 'api' / filename).open('r') as dvla_file:
+    with (Path(current_app.config['LOCAL_FILE_STORAGE_PATH']) / 'api' / filename).open('r', encoding='utf-8') as dvla_file:  # noqa
         return [line.split('|')[4] for line in dvla_file.readlines() if line]
 
 

--- a/tests/app/file_utils/test_file_utils.py
+++ b/tests/app/file_utils/test_file_utils.py
@@ -133,9 +133,9 @@ def test_local_dir_removes_even_if_files_present(client):
 
 def test_get_notification_references_gets_references_from_file(local_api_dir):
     dvla_file_contents = '\n'.join([
-        '140|001|001||ABC0000000000000|||||||||||||1||2|3|4|5|6|WC2B 6NH|||||||||hello',
-        '140|001|001||DEF0000000000000|||||||||||||1||2|3|4|5|6|WC2B 6NH|||||||||hello',
-        '140|001|001||GHI0000000000000|||||||||||||1||2|3|4|5|6|WC2B 6NH|||||||||hello',
+        '140|001|001||ABC0000000000000|||||||||||||1||2|3|4|5|6|WC2B 6NH|||||||||hello🍕',
+        '140|001|001||DEF0000000000000|||||||||||||1||2|3|4|5|6|WC2B 6NH|||||||||hello🌯',
+        '140|001|001||GHI0000000000000|||||||||||||1||2|3|4|5|6|WC2B 6NH|||||||||hello🍔',
         ''
     ])
     path = (local_api_dir / 'foo.txt')


### PR DESCRIPTION
from the docs: "In text mode, if encoding is not specified the encoding used is platform dependent: locale.getpreferredencoding(False) is called to get the current locale encoding"

Locally, that's utf-8, but it appears that it isn't on AWS? So we were seeing encoding errors when trying to read files with unicode chars.