### PR TITLE
Create letter pdf zip

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-import sys
 from flask import current_app
 
 from notifications_utils.s3 import s3upload as utils_s3upload
@@ -103,7 +102,7 @@ def zip_and_send_letter_pdfs(filenames_to_zip):
         "Uploading {file_count} letter PDFs in zip {filename}, size {size} to {bucket}".format(
             file_count=len(filenames_to_zip),
             filename=letter_zip_file_name,
-            size=sys.getsizeof(zip_data),
+            size=len(zip_data),
             bucket=current_app.config['LETTERS_PDF_BUCKET_NAME']
         )
     )

--- a/app/config.py
+++ b/app/config.py
@@ -50,6 +50,8 @@ class Config(object):
     DVLA_JOB_BUCKET_NAME = None
     DVLA_API_BUCKET_NAME = None
 
+    LETTERS_PDF_BUCKET_NAME = None
+
 ######################
 # Config overrides ###
 ######################
@@ -63,6 +65,8 @@ class Development(Config):
     DVLA_JOB_BUCKET_NAME = 'development-dvla-file-per-job'
     DVLA_API_BUCKET_NAME = 'development-dvla-letter-api-files'
 
+    LETTERS_PDF_BUCKET_NAME = 'development-letters-pdf'
+
 
 class Test(Config):
     DEBUG = True
@@ -74,11 +78,15 @@ class Test(Config):
     DVLA_JOB_BUCKET_NAME = 'test-dvla-file-per-job'
     DVLA_API_BUCKET_NAME = 'test-dvla-letter-api-files'
 
+    LETTERS_PDF_BUCKET_NAME = 'test-letters-pdf'
+
 
 class Preview(Config):
 
     DVLA_JOB_BUCKET_NAME = 'preview-dvla-file-per-job'
     DVLA_API_BUCKET_NAME = 'preview-dvla-letter-api-files'
+
+    LETTERS_PDF_BUCKET_NAME = 'preview-letters-pdf'
 
 
 class Staging(Config):
@@ -87,12 +95,16 @@ class Staging(Config):
     DVLA_JOB_BUCKET_NAME = 'staging-dvla-file-per-job'
     DVLA_API_BUCKET_NAME = 'staging-dvla-letter-api-files'
 
+    LETTERS_PDF_BUCKET_NAME = 'staging-letters-pdf'
+
 
 class Production(Config):
     STATSD_ENABLED = True
 
     DVLA_JOB_BUCKET_NAME = 'production-dvla-file-per-job'
     DVLA_API_BUCKET_NAME = 'production-dvla-letter-api-files'
+
+    LETTERS_PDF_BUCKET_NAME = 'live-letters-pdf'
 
 
 configs = {

--- a/app/config.py
+++ b/app/config.py
@@ -104,7 +104,7 @@ class Production(Config):
     DVLA_JOB_BUCKET_NAME = 'production-dvla-file-per-job'
     DVLA_API_BUCKET_NAME = 'production-dvla-letter-api-files'
 
-    LETTERS_PDF_BUCKET_NAME = 'live-letters-pdf'
+    LETTERS_PDF_BUCKET_NAME = 'production-letters-pdf'
 
 
 configs = {

--- a/app/files/file_utils.py
+++ b/app/files/file_utils.py
@@ -9,6 +9,7 @@ from shutil import (
 from flask import current_app
 import boto3
 
+from app.files.in_memory_zip import InMemoryZip
 
 DVLA_FILENAME_FORMAT = 'Notify-%Y%m%d%H%M-rq.txt'
 DVLA_ZIP_FILENAME_FORMAT = 'Notify.%Y%m%d%H%M.zip'
@@ -49,6 +50,27 @@ def get_job_from_s3(job_id):
 def get_api_from_s3(filename):
     bucket_name = current_app.config['DVLA_API_BUCKET_NAME']
     return _get_file_from_s3(bucket_name, 'api', filename)
+
+
+def get_zip_of_letter_pdfs_from_s3(filenames):
+    bucket_name = current_app.config['LETTERS_PDF_BUCKET_NAME']
+    imz = InMemoryZip()
+
+    for filename in filenames:
+        pdf_filename = filename.split('/')[-1]
+        pdf_file = _get_file_from_s3_in_memory(bucket_name, filename)
+        imz.append(pdf_filename, pdf_file)
+
+    return imz.read()
+
+
+def _get_file_from_s3_in_memory(bucket_name, filename):
+    s3 = boto3.resource('s3')
+    obj = s3.Object(
+        bucket_name=bucket_name,
+        key=filename
+    )
+    return obj.get()["Body"].read()
 
 
 def _get_file_from_s3(bucket_name, subfolder, filename):

--- a/app/files/in_memory_zip.py
+++ b/app/files/in_memory_zip.py
@@ -1,0 +1,29 @@
+from io import BytesIO
+import zipfile
+
+
+class InMemoryZip(object):
+    def __init__(self):
+        # Create the in-memory file-like object
+        self.in_memory_zip = BytesIO()
+
+    def append(self, filename_in_zip, file_contents):
+        '''Appends a file with name filename_in_zip and contents of
+        file_contents to the in-memory zip.'''
+        # Get a handle to the in-memory zip in append mode
+        zf = zipfile.ZipFile(self.in_memory_zip, "a", zipfile.ZIP_STORED, False)
+
+        # Write the file to the in-memory zip
+        zf.writestr(filename_in_zip, file_contents)
+
+        # Mark the files as having been created on Windows so that
+        # Unix permissions are not inferred as 0000
+        for zfile in zf.filelist:
+            zfile.create_system = 0
+
+        return self
+
+    def read(self):
+        '''Returns a string with the contents of the in-memory zip.'''
+        self.in_memory_zip.seek(0)
+        return self.in_memory_zip.read()

--- a/app/files/in_memory_zip.py
+++ b/app/files/in_memory_zip.py
@@ -11,15 +11,14 @@ class InMemoryZip(object):
         '''Appends a file with name filename_in_zip and contents of
         file_contents to the in-memory zip.'''
         # Get a handle to the in-memory zip in append mode
-        zf = zipfile.ZipFile(self.in_memory_zip, "a", zipfile.ZIP_STORED, False)
+        with zipfile.ZipFile(self.in_memory_zip, "a", zipfile.ZIP_STORED, False) as zf:
+            # Write the file to the in-memory zip
+            zf.writestr(filename_in_zip, file_contents)
 
-        # Write the file to the in-memory zip
-        zf.writestr(filename_in_zip, file_contents)
-
-        # Mark the files as having been created on Windows so that
-        # Unix permissions are not inferred as 0000
-        for zfile in zf.filelist:
-            zfile.create_system = 0
+            # Mark the files as having been created on Windows so that
+            # Unix permissions are not inferred as 0000
+            for zfile in zf.filelist:
+                zfile.create_system = 0
 
         return self
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,9 +10,6 @@ celery==3.1.25
 monotonic==1.2
 boto3==1.4.4
 
-git+https://github.com/alphagov/notifications-utils.git@23.3.4#egg=notifications-utils==23.3.4
+git+https://github.com/alphagov/notifications-utils.git@23.3.5#egg=notifications-utils==23.3.5
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
-
-# required by utils
-git+https://github.com/leohemsted/smartypants.py.git@regex-speedup#egg=smartypants==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,9 @@ celery==3.1.25
 monotonic==1.2
 boto3==1.4.4
 
-git+https://github.com/alphagov/notifications-utils.git@21.0.0#egg=notifications-utils==21.0.0
+git+https://github.com/alphagov/notifications-utils.git@23.3.4#egg=notifications-utils==23.3.4
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
+
+# required by utils
+git+https://github.com/leohemsted/smartypants.py.git@regex-speedup#egg=smartypants==2.1.0

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -4,7 +4,7 @@ pytest==3.0.7
 pytest-mock==1.6
 pytest-cov==2.3.1
 coveralls==1.1
-moto==0.4.25
+moto==1.1.25
 flex==5.8.0
 freezegun==0.3.7
 requests-mock==1.0.0

--- a/tests/app/celery/test_zip_and_send_letter_pdfs.py
+++ b/tests/app/celery/test_zip_and_send_letter_pdfs.py
@@ -1,0 +1,39 @@
+from flask import current_app
+from freezegun import freeze_time
+import pytest
+
+from app.celery.tasks import zip_and_send_letter_pdfs, LETTER_ZIP_FILE_LOCATION_STRUCTURE
+
+
+@pytest.fixture
+def mocks(mocker, client):
+    class ZipAndSendLetterPDFsMocks:
+        get_zip_of_letter_pdfs_from_s3 = mocker.patch(
+            'app.celery.tasks.get_zip_of_letter_pdfs_from_s3',
+            return_value=b'\x00\x01'
+        )
+        upload_to_s3 = mocker.patch('app.celery.tasks.utils_s3upload')
+        send_file = mocker.patch('app.celery.tasks.ftp_client.send_file')
+    with freeze_time('2017-01-01 17:30'):
+        yield ZipAndSendLetterPDFsMocks
+
+
+def test_should_get_zip_of_letter_pdfs_from_s3(mocks):
+    filenames = ['2017-01-01/TEST1.PDF', '2017-01-01/TEST2.PDF']
+
+    zip_and_send_letter_pdfs(filenames)
+
+    mocks.get_zip_of_letter_pdfs_from_s3.assert_called_once_with(filenames)
+
+
+def test_should_upload_zip_of_letter_pdfs_to_s3(notify_ftp, mocks):
+    filenames = ['2017-01-01/TEST1.PDF']
+
+    zip_and_send_letter_pdfs(filenames)
+    location = LETTER_ZIP_FILE_LOCATION_STRUCTURE.format(folder='2017-01-01', date='20170101173000')
+    mocks.upload_to_s3.assert_called_once_with(
+        bucket_name=current_app.config['LETTERS_PDF_BUCKET_NAME'],
+        file_location=location,
+        filedata=b'\x00\x01',
+        region='eu-west-1'
+    )


### PR DESCRIPTION
## What

Adds a celery task that accepts a list of filenames (letter pdfs) and uses them to get the file contents from s3 creating a zip in memory. 

The zip file will be uploaded back on to the letters pdf s3 bucket on the folder where the pdfs were downloaded from, this will a temporary holding place until the zip file gets sent to DVLA and we have confidence of the end to end letter PDFs processing.

## Reference 

Step 3 / 5 - https://www.pivotaltracker.com/story/show/151511632