### PR TITLE
notify_celery was originally dropped as unused but it's actually used to start celery

### DIFF
--- a/aws_run_celery.py
+++ b/aws_run_celery.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from app import create_app
+from app import notify_celery, create_app  # noqa: notify_celery required to get celery running
 from credstash import getAllSecrets
 import os
 

--- a/run_celery.py
+++ b/run_celery.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from app import create_app
+from app import notify_celery, create_app  # noqa: notify_celery required to get celery running
 
 application = create_app()
 application.app_context().push()


### PR DESCRIPTION
## What

notify_celery was incorrectly dropped as an import, have now added them back in as needed to start up celery tasks