### PR TITLE
Fix incorrect formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To run the FTP application, you will need appropriate AWS credentials. You shoul
 
 Your aws credentials should be stored in a folder located at `~/.aws`. Follow [Amazon's instructions](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-config-files) for storing them correctly.
 
-### Virtualenv
+### Virtualenv
 
 ```
 mkvirtualenv -p /usr/local/bin/python3 notifications-ftp
@@ -49,4 +49,3 @@ make build test
 ```
 
 That will run flake8 for code analysis and our unit test suite.
-=======


### PR DESCRIPTION
There was no-break space character in the Virtualenv heading which means it
wasn't rendering in Markdown, and a footer which was accidentally rendering the
last line as a header.