### PR TITLE
Bump utils

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ celery==3.1.25
 monotonic==1.2
 boto3==1.4.4
 
-git+https://github.com/alphagov/notifications-utils.git@23.3.5#egg=notifications-utils==23.3.5
+git+https://github.com/alphagov/notifications-utils.git@26.3.0#egg=notifications-utils==26.3.0
 
 git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3


### PR DESCRIPTION
Fixes exceptions caused by upgrade to pip 10.

Changes: https://github.com/alphagov/notifications-utils/compare/23.3.5...26.3.0