### PR TITLE
Locking boto3 is breaking aws-cli

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ Flask==0.10.1
 Flask-Script==2.0.5
 celery==3.1.25
 monotonic==1.2
-boto3==1.4.4
 
 git+https://github.com/alphagov/notifications-utils.git@28.1.0#egg=notifications-utils==28.1.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ Flask-Script==2.0.5
 celery==3.1.25
 monotonic==1.2
 boto3==1.6.16
+awscli==1.14.70
 
 git+https://github.com/alphagov/notifications-utils.git@28.1.0#egg=notifications-utils==28.1.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ Flask==0.10.1
 Flask-Script==2.0.5
 celery==3.1.25
 monotonic==1.2
+boto3==1.6.16
 
 git+https://github.com/alphagov/notifications-utils.git@28.1.0#egg=notifications-utils==28.1.0
 


### PR DESCRIPTION
The notifications-utils package installs up-to-date versions which break with the locked version.