### PR TITLE
pin cffi to 1.11.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+cffi==1.11.5
+gunicorn==19.9.0
 pyftpdlib==1.5.4
 pysftp==0.2.9
 credstash==1.14.0


### PR DESCRIPTION
cryptography (sub-dependency of credstash) tries to install cffi from within its setup.py - this is having issues (possibly related to our egress proxy), so lets try installing cffi ourselves.

also add gunicorn because it's definitely a dependency that we forgot