### PR TITLE
Check file exists after an exception

### DIFF
--- a/app/sftp/ftp_client.py
+++ b/app/sftp/ftp_client.py
@@ -57,11 +57,21 @@ def upload_zip(sftp, zip_data, filename, statsd_client):
             filename
         ))
 
-    with sftp.open('{}/{}'.format(sftp.pwd, filename), mode='xw') as remote_file:
-        remote_file.write(zip_data)
+    try:
+        with sftp.open('{}/{}'.format(sftp.pwd, filename), mode='xw') as remote_file:
+            remote_file.write(zip_data)
+    except OSError as e:
+        current_app.logger.exception(
+            "Exception occurred when uploading zip, checking if file was uploaded with the right size"
+        )
+        check_file_uploaded(filename, sftp, zip_data_len)
 
     statsd_client.timing("ftp-client.zip-upload-time", monotonic() - start_time)
 
+    check_file_uploaded(filename, sftp, zip_data_len)
+
+
+def check_file_uploaded(filename, sftp, zip_data_len):
     if filename in sftp.listdir():
         stats = sftp.lstat('{}/{}'.format(sftp.pwd, filename))
         if stats.st_size != zip_data_len:


### PR DESCRIPTION
On November 6, we got a few exceptions when sending the files to DVLA, this resulted in us sending the files 2 or 3 times (resulting in sending over 10,000 extra letters).

Luckily they noticed that some of files were duplicate.
This PR tries to prevent that by checking the file exists with the right name and size on the remote server.