### PR TITLE
Add a check for the file before allowing the task to retry (for upload_zip)

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -103,8 +103,13 @@ def zip_and_send_letter_pdfs(filenames_to_zip):
         current_app.logger.exception('FTP app failed to download PDF from S3 bucket {}'.format(folder_date))
         task_name = "update-letter-notifications-to-error"
     except FtpException:
-        current_app.logger.exception('FTP app failed to send api messages')
-        task_name = "update-letter-notifications-to-error"
+        try:
+            # check if file exists with the right size.
+            # It has happened that an IOError occurs but the files are present on the remote server.
+            ftp_client.file_exists_with_correct_size(zip_file_name, len(zip_data))
+        except FtpException:
+            current_app.logger.exception('FTP app failed to send api messages')
+            task_name = "update-letter-notifications-to-error"
     else:
         task_name = "update-letter-notifications-to-sent"
 

--- a/app/files/file_utils.py
+++ b/app/files/file_utils.py
@@ -53,15 +53,10 @@ def get_api_from_s3(filename):
 
 
 def get_zip_of_letter_pdfs_from_s3(filenames):
-    folder_date = filenames[0].split('/')[0]
-
     bucket_name = current_app.config['LETTERS_PDF_BUCKET_NAME']
     imz = InMemoryZip()
 
     for i, filename in enumerate(filenames):
-        if i % 100 == 0:
-            current_app.logger.info('Zipping {} of {} letter PDFs from {}'.format(
-                i, len(filenames), folder_date))
         pdf_filename = filename.split('/')[-1]
         pdf_file = _get_file_from_s3_in_memory(bucket_name, filename)
         imz.append(pdf_filename, pdf_file)

--- a/tests/app/sftp/test_ftp_client.py
+++ b/tests/app/sftp/test_ftp_client.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 import pytest
 from freezegun import freeze_time
 
-from app.sftp.ftp_client import upload_file, upload_zip, FtpException
+from app.sftp.ftp_client import upload_file, upload_zip, FtpException, check_file_exist_and_is_right_size
 
 
 @pytest.fixture
@@ -121,3 +121,49 @@ def test_send_zip_errors_if_remote_file_size_is_different(mocks):
 
     with pytest.raises(FtpException):
         upload_zip(mock_zip_sftp, mocks.mock_data, mocks.mock_remote_filename, Mock())
+
+
+def test_file_exists_with_correct_size(mocks):
+    zip_data = b'some data'
+    remote_filename = "a-file-that-worked-but-still-threw-exception.zip"
+    mock_sftp = Mock(
+        pwd='~/notify',
+        exists=Mock(return_value=False),
+        listdir=Mock(return_value=[remote_filename]),
+        lstat=Mock(return_value=Mock(st_size=len(zip_data))),
+    )
+
+    check_file_exist_and_is_right_size(mock_sftp, remote_filename, len(zip_data))
+    mock_sftp.lstat.assert_called_once_with('~/notify/{}'.format(remote_filename))
+
+
+def test_file_exists_with_correct_size_throws_exception_when_file_does_not_exist(mocks):
+    zip_data = b'some data'
+    remote_filename = "file_does_not_exist_remotely.zip"
+    mock_sftp = Mock(
+        pwd='~/notify',
+        exists=Mock(return_value=False),
+        listdir=Mock(return_value=["any-file-but-the-right-one"]),
+    )
+
+    with pytest.raises(expected_exception=FtpException) as e:
+        check_file_exist_and_is_right_size(mock_sftp, remote_filename, len(zip_data))
+        assert e.value == "Zip file {} not uploaded".format(remote_filename)
+    mock_sftp.listdir.assert_called_once_with()
+
+
+def test_file_exists_with_correct_size_throws_exception_file_exists_with_wrong_size(mocks):
+    zip_data = b'some data'
+    remote_filename = "file_does_not_exist_remotely.zip"
+    mock_sftp = Mock(
+        pwd='~/notify',
+        exists=Mock(return_value=False),
+        listdir=Mock(return_value=[remote_filename]),
+        lstat=Mock(st_size=1)
+    )
+
+    with pytest.raises(expected_exception=FtpException) as e:
+        check_file_exist_and_is_right_size(mock_sftp, remote_filename, len(zip_data))
+        assert e.value == "Zip file {} uploaded but size is incorrect: is {}, expected {}d".format(
+            remote_filename, len(zip_data), 1)
+    mock_sftp.lstat.assert_called_once_with('~/notify/{}'.format(remote_filename))


### PR DESCRIPTION
We had a situation where the zip files successfully uploaded to the remote server, but there was a OSError, which caused the task to retry. Resulting in 3 extra files being send over, since we uniquely name each file, 3 extra files were sent. This could have resulted in about 12000 extra letters (quite expensive). Luckily our mail provider spotted the duplicates and the extra files were ignored.

In this PR, a check for the file has been added. We check that the file exists and is the right file size.