### PR TITLE
Bump requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@
 SHELL := /bin/bash
 DATE = $(shell date +%Y-%m-%d:%H:%M:%S)
 
-PIP_ACCEL_CACHE ?= ${CURDIR}/cache/pip-accel
 APP_VERSION_FILE = app/version.py
 
 GIT_BRANCH ?= $(shell git symbolic-ref --short HEAD 2> /dev/null || echo "detached")

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -49,6 +49,7 @@ def zip_and_send_letter_pdfs(filenames_to_zip):
             # check if file exists with the right size.
             # It has happened that an IOError occurs but the files are present on the remote server.
             ftp_client.file_exists_with_correct_size(zip_file_name, len(zip_data))
+            task_name = "update-letter-notifications-to-sent"
         except FtpException:
             current_app.logger.exception('FTP app failed to send api messages')
             task_name = "update-letter-notifications-to-error"

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,5 @@
 testpaths = tests
 env =
     NOTIFY_ENVIRONMENT=test
+    AWS_SECRET_ACCESS_KEY=
+    AWS_ACCESS_KEY_ID=

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-cffi==1.11.5
+cffi==1.12.1
 gunicorn==19.9.0
 pyftpdlib==1.5.4
 pysftp==0.2.9
-credstash==1.14.0
+credstash==1.15.0 
 Flask==1.0.2
 celery==3.1.26.post2 # pyup: <4
 

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,9 +1,9 @@
 -r requirements.txt
-flake8==3.7.3
-pytest==3.6.2
-pytest-mock==1.10.0
-pytest-cov==2.5.1
+coveralls==1.6.0
+flake8==3.7.6
+freezegun==0.3.11
+moto==1.3.7
+pytest-cov==2.6.1
 pytest-env==0.6.2
-coveralls==1.3.0
-moto==1.3.3
-freezegun==0.3.10
+pytest-mock==1.10.1
+pytest==4.3.0


### PR DESCRIPTION
also fix flow when an exception is raised while ftping a file - previously the task_name variable wouldn't have been defined
