### PR TITLE
Define a filename before uploading file to DVLA

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -18,19 +18,20 @@ NOTIFY_QUEUE = 'notify-internal-tasks'
 
 @notify_celery.task(name="zip-and-send-letter-pdfs")
 @statsd(namespace="tasks")
-def zip_and_send_letter_pdfs(filenames_to_zip):
+def zip_and_send_letter_pdfs(filenames_to_zip, upload_filename=None):
     folder_date = filenames_to_zip[0].split('/')[0]
+    zip_file_name = upload_filename or get_dvla_file_name(file_ext='.zip')
 
     current_app.logger.info(
-        "Starting to zip {file_count} letter PDFs in memory from {folder}".format(
+        "Starting to zip {file_count} letter PDFs in memory from {folder} into dvla file {upload_filename}".format(  # noqa
             file_count=len(filenames_to_zip),
-            folder=folder_date
+            folder=folder_date,
+            upload_filename=zip_file_name
         )
     )
 
     try:
         zip_data = get_zip_of_letter_pdfs_from_s3(filenames_to_zip)
-        zip_file_name = get_dvla_file_name(file_ext='.zip')
 
         # upload a record to s3 of each zip file we send to DVLA - this is just a list of letter filenames so we can
         # match up their references with DVLA

--- a/app/files/file_utils.py
+++ b/app/files/file_utils.py
@@ -1,5 +1,4 @@
-import os
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from flask import current_app
 import boto3
@@ -13,14 +12,6 @@ DVLA_ZIP_FILENAME_FORMAT = 'NOTIFY.%Y%m%d%H%M%S.ZIP'
 def get_dvla_file_name(dt=None, file_ext='.txt'):
     dt = dt or datetime.utcnow()
     return dt.strftime(_get_dvla_format(file_ext))
-
-
-def get_new_dvla_filename(old_filename):
-    file_ext = os.path.splitext(old_filename)[1]
-    # increment the time by one minute
-    old_datetime = datetime.strptime(old_filename, _get_dvla_format(file_ext))
-
-    return get_dvla_file_name(dt=old_datetime + timedelta(minutes=1), file_ext=file_ext)
 
 
 def get_zip_of_letter_pdfs_from_s3(filenames):

--- a/tests/app/celery/test_zip_and_send_letter_pdfs.py
+++ b/tests/app/celery/test_zip_and_send_letter_pdfs.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from unittest.mock import call
+from unittest.mock import call, ANY
 
 from flask import current_app
 from freezegun import freeze_time
@@ -143,3 +143,16 @@ def test_zip_and_send_should_update_notifications_to_success_in_1k_batches(mocke
     assert mocks.send_task.mock_calls[0][2]['args'] == (list(range(1000)),)
     assert mocks.send_task.mock_calls[1][2]['args'] == (list(range(1000, 2000)),)
     assert mocks.send_task.mock_calls[2][2]['args'] == (list(range(2000, 3000)),)
+
+
+def test_zip_and_send_accepts_a_specified_filename(mocks):
+    filenames = ['2017-01-01/TEST1.PDF']
+    zip_and_send_letter_pdfs(filenames, upload_filename='MY_NAME.ZIP')
+
+    mocks.send_zip.assert_called_once_with(ANY, 'MY_NAME.ZIP')
+    mocks.upload_to_s3.assert_called_once_with(
+        bucket_name=ANY,
+        file_location='2017-01-01/zips_sent/MY_NAME.ZIP.TXT',
+        filedata=ANY,
+        region=ANY
+    )

--- a/tests/app/file_utils/test_file_utils.py
+++ b/tests/app/file_utils/test_file_utils.py
@@ -9,7 +9,6 @@ from flask import current_app
 from freezegun import freeze_time
 from app.files.file_utils import (
     get_dvla_file_name,
-    get_new_dvla_filename,
     get_zip_of_letter_pdfs_from_s3,
     _get_file_from_s3_in_memory,
     get_notification_references_from_s3_filenames
@@ -27,15 +26,6 @@ FOO_SUBFOLDER = '/tmp/dvla-file-storage/foo'
 def test_get_dvla_file_name(file_ext, remote_filename):
     with freeze_time('2016-01-01T17:00:00'):
         assert get_dvla_file_name(file_ext=file_ext) == remote_filename
-
-
-@pytest.mark.parametrize('old_filename,remote_filename', [
-    ('Notify-201601011759-rq.txt', 'Notify-201601011800-rq.txt'),
-    ('NOTIFY.20160101175900.ZIP', 'NOTIFY.20160101180000.ZIP')
-])
-def test_get_new_dvla_file_name(old_filename, remote_filename):
-    # increment from 17:59 to 18:00
-    assert get_new_dvla_filename(old_filename) == remote_filename
 
 
 def test_get_notification_references_from_s3():


### PR DESCRIPTION
currently optional for backwards compatibility, but i'll remove that option in a future PR.

Previously:

* create filename based on current timestamp.
* if file existed, change filename of new file by incrementing timestamp
* upload file
* check that file exists with right filesize

Now:

* filename is passed in (if it's not, then fall back to creating based on current timestamp)
* if file exists, check its filesize
  - if the filesize matches, return without doing anything
* upload file (overwriting any existing file)
* check that file exists with right filesize