### PR TITLE
Make it mandatory to define a filename for a DVLA upload

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -8,7 +8,6 @@ from app import notify_celery, ftp_client
 from app.files.file_utils import (
     get_zip_of_letter_pdfs_from_s3,
     get_notification_references_from_s3_filenames,
-    get_dvla_file_name,
 )
 from app.statsd_decorators import statsd
 from app.sftp.ftp_client import FtpException
@@ -18,15 +17,14 @@ NOTIFY_QUEUE = 'notify-internal-tasks'
 
 @notify_celery.task(name="zip-and-send-letter-pdfs")
 @statsd(namespace="tasks")
-def zip_and_send_letter_pdfs(filenames_to_zip, upload_filename=None):
+def zip_and_send_letter_pdfs(filenames_to_zip, upload_filename):
     folder_date = filenames_to_zip[0].split('/')[0]
-    zip_file_name = upload_filename or get_dvla_file_name(file_ext='.zip')
 
     current_app.logger.info(
         "Starting to zip {file_count} letter PDFs in memory from {folder} into dvla file {upload_filename}".format(  # noqa
             file_count=len(filenames_to_zip),
             folder=folder_date,
-            upload_filename=zip_file_name
+            upload_filename=upload_filename
         )
     )
 
@@ -39,9 +37,9 @@ def zip_and_send_letter_pdfs(filenames_to_zip, upload_filename=None):
             filedata=json.dumps(filenames_to_zip).encode(),
             region=current_app.config['AWS_REGION'],
             bucket_name=current_app.config['LETTERS_PDF_BUCKET_NAME'],
-            file_location='{}/zips_sent/{}.TXT'.format(folder_date, zip_file_name)
+            file_location='{}/zips_sent/{}.TXT'.format(folder_date, upload_filename)
         )
-        ftp_client.send_zip(zip_data, zip_file_name)
+        ftp_client.send_zip(zip_data, upload_filename)
     except ClientError:
         current_app.logger.exception('FTP app failed to download PDF from S3 bucket {}'.format(folder_date))
         task_name = "update-letter-notifications-to-error"
@@ -49,7 +47,7 @@ def zip_and_send_letter_pdfs(filenames_to_zip, upload_filename=None):
         try:
             # check if file exists with the right size.
             # It has happened that an IOError occurs but the files are present on the remote server.
-            ftp_client.file_exists_with_correct_size(zip_file_name, len(zip_data))
+            ftp_client.file_exists_with_correct_size(upload_filename, len(zip_data))
             task_name = "update-letter-notifications-to-sent"
         except FtpException:
             current_app.logger.exception('FTP app failed to send api messages')

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -31,6 +31,8 @@ def zip_and_send_letter_pdfs(filenames_to_zip, upload_filename):
     try:
         zip_data = get_zip_of_letter_pdfs_from_s3(filenames_to_zip)
 
+        ftp_client.send_zip(zip_data, upload_filename)
+
         # upload a record to s3 of each zip file we send to DVLA - this is just a list of letter filenames so we can
         # match up their references with DVLA
         utils_s3upload(
@@ -39,7 +41,6 @@ def zip_and_send_letter_pdfs(filenames_to_zip, upload_filename):
             bucket_name=current_app.config['LETTERS_PDF_BUCKET_NAME'],
             file_location='{}/zips_sent/{}.TXT'.format(folder_date, upload_filename)
         )
-        ftp_client.send_zip(zip_data, upload_filename)
     except ClientError:
         current_app.logger.exception('FTP app failed to download PDF from S3 bucket {}'.format(folder_date))
         task_name = "update-letter-notifications-to-error"

--- a/app/files/file_utils.py
+++ b/app/files/file_utils.py
@@ -1,17 +1,7 @@
-from datetime import datetime
-
 from flask import current_app
 import boto3
 
 from app.files.in_memory_zip import InMemoryZip
-
-DVLA_FILENAME_FORMAT = 'Notify-%Y%m%d%H%M-rq.txt'
-DVLA_ZIP_FILENAME_FORMAT = 'NOTIFY.%Y%m%d%H%M%S.ZIP'
-
-
-def get_dvla_file_name(dt=None, file_ext='.txt'):
-    dt = dt or datetime.utcnow()
-    return dt.strftime(_get_dvla_format(file_ext))
 
 
 def get_zip_of_letter_pdfs_from_s3(filenames):
@@ -38,11 +28,3 @@ def _get_file_from_s3_in_memory(bucket_name, filename):
         key=filename
     )
     return obj.get()["Body"].read()
-
-
-def _get_dvla_format(file_ext='.txt'):
-    if file_ext and file_ext.lower() == '.zip':
-        dvla_format = DVLA_ZIP_FILENAME_FORMAT
-    else:
-        dvla_format = DVLA_FILENAME_FORMAT
-    return dvla_format

--- a/tests/app/celery/test_zip_and_send_letter_pdfs.py
+++ b/tests/app/celery/test_zip_and_send_letter_pdfs.py
@@ -1,5 +1,4 @@
-from datetime import datetime
-from unittest.mock import call, ANY
+from unittest.mock import call
 
 from flask import current_app
 from freezegun import freeze_time
@@ -7,7 +6,6 @@ import pytest
 from botocore.exceptions import ClientError
 
 from app.celery.tasks import zip_and_send_letter_pdfs
-from app.files.file_utils import get_dvla_file_name
 from app.sftp.ftp_client import FtpException
 
 
@@ -36,21 +34,20 @@ def mocks(mocker, client):
 def test_should_get_zip_of_letter_pdfs_from_s3(mocks):
     filenames = ['2017-01-01/TEST1.PDF', '2017-01-01/TEST2.PDF']
 
-    zip_and_send_letter_pdfs(filenames)
+    zip_and_send_letter_pdfs(filenames, 'foo.zip')
 
     mocks.get_zip_of_letter_pdfs_from_s3.assert_called_once_with(filenames)
 
 
 def test_should_upload_record_of_zipfile_contents_to_s3(notify_ftp, mocks):
     filenames = ['2017-01-01/TEST1.PDF']
-    zip_filename = get_dvla_file_name(dt=datetime(2017, 1, 1, 17, 30), file_ext='.zip')
 
-    zip_and_send_letter_pdfs(filenames)
+    zip_and_send_letter_pdfs(filenames, 'foo.zip')
 
     assert mocks.upload_to_s3.call_args_list == [
         call(
             bucket_name=current_app.config['LETTERS_PDF_BUCKET_NAME'],
-            file_location='{}/zips_sent/{}.TXT'.format('2017-01-01', zip_filename),
+            file_location='2017-01-01/zips_sent/foo.zip.TXT',
             filedata=b'["2017-01-01/TEST1.PDF"]',
             region='eu-west-1'
         )
@@ -60,18 +57,15 @@ def test_should_upload_record_of_zipfile_contents_to_s3(notify_ftp, mocks):
 def test_should_send_zip_file(mocks):
     filenames = ['2017-01-01/TEST1.PDF']
 
-    zip_and_send_letter_pdfs(filenames)
-    zip_filename = get_dvla_file_name(dt=datetime(2017, 1, 1, 17, 30), file_ext='.zip')
+    zip_and_send_letter_pdfs(filenames, 'foo.zip')
 
-    mocks.send_zip.assert_called_once_with(
-        b'\x00\x01', zip_filename
-    )
+    mocks.send_zip.assert_called_once_with(b'\x00\x01', 'foo.zip')
 
 
 def test_should_get_references_out_of_s3_filenames(mocks):
     filenames = ['2017-01-01/TEST1.PDF']
 
-    zip_and_send_letter_pdfs(filenames)
+    zip_and_send_letter_pdfs(filenames, 'foo.zip')
 
     mocks.get_notification_references_from_s3_filenames.assert_called_once_with(filenames)
 
@@ -79,7 +73,7 @@ def test_should_get_references_out_of_s3_filenames(mocks):
 def test_zip_and_send_should_update_notifications_to_success(mocks):
     filenames = ['2017-01-01/TEST1.PDF']
 
-    zip_and_send_letter_pdfs(filenames)
+    zip_and_send_letter_pdfs(filenames, 'foo.zip')
 
     assert not mocks.file_exists_with_correct_size.called
     mocks.send_task.assert_called_once_with(
@@ -93,7 +87,7 @@ def test_zip_and_send_should_update_notifications_if_s3_client_error(mocks):
     mocks.get_zip_of_letter_pdfs_from_s3.side_effect = ClientError({}, 'operation')
 
     filenames = ['2017-01-01/TEST1.PDF']
-    zip_and_send_letter_pdfs(filenames)
+    zip_and_send_letter_pdfs(filenames, 'foo.zip')
 
     mocks.send_task.assert_called_once_with(
         name='update-letter-notifications-to-error',
@@ -107,9 +101,9 @@ def test_zip_and_send_should_update_notifications_to_error_if_send_zip_fails_and
     mocks.file_exists_with_correct_size.side_effect = FtpException
 
     filenames = ['2017-01-01/TEST1.PDF']
-    zip_and_send_letter_pdfs(filenames)
+    zip_and_send_letter_pdfs(filenames, 'foo.zip')
 
-    mocks.file_exists_with_correct_size.assert_called_once_with('NOTIFY.20170101173000.ZIP', 2)
+    mocks.file_exists_with_correct_size.assert_called_once_with('foo.zip', 2)
     mocks.send_task.assert_called_once_with(
         name='update-letter-notifications-to-error',
         args=(['1', '2', '3'],),
@@ -121,9 +115,9 @@ def test_zip_and_send_should_update_notifications_to_success_if_send_zip_fails_b
     mocks.send_zip.side_effect = FtpException
 
     filenames = ['2017-01-01/TEST1.PDF']
-    zip_and_send_letter_pdfs(filenames)
+    zip_and_send_letter_pdfs(filenames, 'foo.zip')
 
-    mocks.file_exists_with_correct_size.assert_called_once_with('NOTIFY.20170101173000.ZIP', 2)
+    mocks.file_exists_with_correct_size.assert_called_once_with('foo.zip', 2)
     mocks.send_task.assert_called_once_with(
         name='update-letter-notifications-to-sent',
         args=(['1', '2', '3'],),
@@ -137,22 +131,9 @@ def test_zip_and_send_should_update_notifications_to_success_in_1k_batches(mocke
         return_value=list(range(10000))
     )
     filenames = ['2017-01-01/TEST1.PDF']
-    zip_and_send_letter_pdfs(filenames)
+    zip_and_send_letter_pdfs(filenames, 'foo.zip')
 
     assert mocks.send_task.call_count == 10
     assert mocks.send_task.mock_calls[0][2]['args'] == (list(range(1000)),)
     assert mocks.send_task.mock_calls[1][2]['args'] == (list(range(1000, 2000)),)
     assert mocks.send_task.mock_calls[2][2]['args'] == (list(range(2000, 3000)),)
-
-
-def test_zip_and_send_accepts_a_specified_filename(mocks):
-    filenames = ['2017-01-01/TEST1.PDF']
-    zip_and_send_letter_pdfs(filenames, upload_filename='MY_NAME.ZIP')
-
-    mocks.send_zip.assert_called_once_with(ANY, 'MY_NAME.ZIP')
-    mocks.upload_to_s3.assert_called_once_with(
-        bucket_name=ANY,
-        file_location='2017-01-01/zips_sent/MY_NAME.ZIP.TXT',
-        filedata=ANY,
-        region=ANY
-    )

--- a/tests/app/file_utils/test_file_utils.py
+++ b/tests/app/file_utils/test_file_utils.py
@@ -4,11 +4,9 @@ from zipfile import ZipFile
 
 import boto3
 from moto import mock_s3
-import pytest
 from flask import current_app
-from freezegun import freeze_time
+
 from app.files.file_utils import (
-    get_dvla_file_name,
     get_zip_of_letter_pdfs_from_s3,
     _get_file_from_s3_in_memory,
     get_notification_references_from_s3_filenames
@@ -16,16 +14,6 @@ from app.files.file_utils import (
 
 
 FOO_SUBFOLDER = '/tmp/dvla-file-storage/foo'
-
-
-@pytest.mark.parametrize('file_ext,remote_filename', [
-    (None, 'Notify-201601011700-rq.txt'),
-    ('.txt', 'Notify-201601011700-rq.txt'),
-    ('.zip', 'NOTIFY.20160101170000.ZIP')
-])
-def test_get_dvla_file_name(file_ext, remote_filename):
-    with freeze_time('2016-01-01T17:00:00'):
-        assert get_dvla_file_name(file_ext=file_ext) == remote_filename
 
 
 def test_get_notification_references_from_s3():


### PR DESCRIPTION
- [x] https://github.com/alphagov/notifications-ftp/pull/228
- [x] https://github.com/alphagov/notifications-api/pull/2405

Turn off the optional code, remove bits that are now unused