### PR TITLE
don't upload to dvla if file already in zips_sent

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -8,6 +8,7 @@ from app import notify_celery, ftp_client
 from app.files.file_utils import (
     get_zip_of_letter_pdfs_from_s3,
     get_notification_references_from_s3_filenames,
+    file_exists_on_s3
 )
 from app.statsd_decorators import statsd
 from app.sftp.ftp_client import FtpException
@@ -19,6 +20,7 @@ NOTIFY_QUEUE = 'notify-internal-tasks'
 @statsd(namespace="tasks")
 def zip_and_send_letter_pdfs(filenames_to_zip, upload_filename):
     folder_date = filenames_to_zip[0].split('/')[0]
+    zips_sent_filename = '{}/zips_sent/{}.TXT'.format(folder_date, upload_filename)
 
     current_app.logger.info(
         "Starting to zip {file_count} letter PDFs in memory from {folder} into dvla file {upload_filename}".format(  # noqa
@@ -29,6 +31,10 @@ def zip_and_send_letter_pdfs(filenames_to_zip, upload_filename):
     )
 
     try:
+        if file_exists_on_s3(current_app.config['LETTERS_PDF_BUCKET_NAME'], zips_sent_filename):
+            current_app.logger.error('{} already exists, skipping dvla upload')
+            return
+
         zip_data = get_zip_of_letter_pdfs_from_s3(filenames_to_zip)
 
         ftp_client.send_zip(zip_data, upload_filename)
@@ -39,7 +45,7 @@ def zip_and_send_letter_pdfs(filenames_to_zip, upload_filename):
             filedata=json.dumps(filenames_to_zip).encode(),
             region=current_app.config['AWS_REGION'],
             bucket_name=current_app.config['LETTERS_PDF_BUCKET_NAME'],
-            file_location='{}/zips_sent/{}.TXT'.format(folder_date, upload_filename)
+            file_location=zips_sent_filename
         )
     except ClientError:
         current_app.logger.exception('FTP app failed to download PDF from S3 bucket {}'.format(folder_date))

--- a/tests/app/celery/test_zip_and_send_letter_pdfs.py
+++ b/tests/app/celery/test_zip_and_send_letter_pdfs.py
@@ -21,6 +21,10 @@ def mocks(mocker, client):
         file_exists_with_correct_size = mocker.patch(
             'app.celery.tasks.ftp_client.file_exists_with_correct_size'
         )
+        file_exists_on_s3 = mocker.patch(
+            'app.celery.tasks.file_exists_on_s3',
+            return_value=False
+        )
         send_task = mocker.patch('app.notify_celery.send_task')
         get_notification_references_from_s3_filenames = mocker.patch(
             'app.celery.tasks.get_notification_references_from_s3_filenames',
@@ -137,3 +141,30 @@ def test_zip_and_send_should_update_notifications_to_success_in_1k_batches(mocke
     assert mocks.send_task.mock_calls[0][2]['args'] == (list(range(1000)),)
     assert mocks.send_task.mock_calls[1][2]['args'] == (list(range(1000, 2000)),)
     assert mocks.send_task.mock_calls[2][2]['args'] == (list(range(2000, 3000)),)
+
+
+def test_zip_and_send_should_skip_if_record_already_in_zips_sent(mocks):
+    mocks.file_exists_on_s3.return_value = True
+
+    filenames = ['2017-01-01/TEST1.PDF']
+    zip_and_send_letter_pdfs(filenames, 'foo.zip')
+
+    mocks.file_exists_on_s3.assert_called_once_with(
+        current_app.config['LETTERS_PDF_BUCKET_NAME'],
+        '2017-01-01/zips_sent/foo.zip.TXT',
+    )
+    # no update notification tasks should be triggered
+    assert mocks.send_task.call_count == 0
+
+
+def test_zip_and_send_should_set_to_error_if_cant_check_zips_sent(mocks):
+    mocks.file_exists_on_s3.side_effect = ClientError({}, 'operation')
+
+    filenames = ['2017-01-01/TEST1.PDF']
+    zip_and_send_letter_pdfs(filenames, 'foo.zip')
+
+    mocks.send_task.assert_called_once_with(
+        name='update-letter-notifications-to-error',
+        args=(['1', '2', '3'],),
+        queue='notify-internal-tasks'
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from flask import Flask, current_app
 from app import create_app
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope='session', autouse=True)
 def notify_ftp():
     app = Flask('test')
     app = create_app(app)


### PR DESCRIPTION
we can't rely on checking if the file is already present on dvla's ftp server to see if we've already uploaded it - dvla might have already deleted the file by the time the duplicate task runs. We upload a record of the files we uploaded to the zips_sent subfolder in our s3 bucket as soon as we finish the ftp transfer, so we can check to see if that file exists before we try commencing another ftp, in case we're in a second duplicate the ftp transfer, so we can check to see if that file exists before we try commencing another ftp, in case we're in a second duplicate task

this isn't foolproof (a second task could run the check just before the first task uploads the zips_sent), however in that case it's likely that the ftp will fail as the file should still be on the remote server if it's within seconds.