### PR TITLE
Turn statsd off for the FTP application in production.

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -92,7 +92,7 @@ class Preview(Config):
 
 
 class Staging(Config):
-    STATSD_ENABLED = True
+    STATSD_ENABLED = False
 
     DVLA_JOB_BUCKET_NAME = 'staging-dvla-file-per-job'
     DVLA_API_BUCKET_NAME = 'staging-dvla-letter-api-files'
@@ -101,7 +101,7 @@ class Staging(Config):
 
 
 class Production(Config):
-    STATSD_ENABLED = True
+    STATSD_ENABLED = False
 
     DVLA_JOB_BUCKET_NAME = 'production-dvla-file-per-job'
     DVLA_API_BUCKET_NAME = 'production-dvla-letter-api-files'


### PR DESCRIPTION
We no longer push stats to hosted graphite. Prometheus is the preferred choice for GDS.
I have left the statsd client and annotation for now. Once we get FTP running on PaaS we can turn this back on and send the stas to prometheus.