### PR TITLE
Downgrade error to warning

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -32,7 +32,7 @@ def zip_and_send_letter_pdfs(filenames_to_zip, upload_filename):
 
     try:
         if file_exists_on_s3(current_app.config['LETTERS_PDF_BUCKET_NAME'], zips_sent_filename):
-            current_app.logger.error('{} already exists, skipping dvla upload'.format(zips_sent_filename))
+            current_app.logger.warning('{} already exists in S3, skipping DVLA upload'.format(zips_sent_filename))
             return
 
         zip_data = get_zip_of_letter_pdfs_from_s3(filenames_to_zip)

--- a/tests/app/celery/test_zip_and_send_letter_pdfs.py
+++ b/tests/app/celery/test_zip_and_send_letter_pdfs.py
@@ -156,7 +156,7 @@ def test_zip_and_send_should_skip_if_record_already_in_zips_sent(mocks, caplog):
     # no update notification tasks should be triggered
     assert mocks.send_task.call_count == 0
     assert any(
-        rec.message == '2017-01-01/zips_sent/foo.zip.TXT already exists, skipping dvla upload'
+        rec.message == '2017-01-01/zips_sent/foo.zip.TXT already exists in S3, skipping DVLA upload'
         for rec in caplog.records
     )
 


### PR DESCRIPTION
- Now that this app is in PaaS, we get emails from Logit for all errors
  in it
- This error seems to go off a lot but realistically isn't an error as
  we are guarding against it
- Downgrade it to warning to prevent email spam