### PR TITLE
Ignore the celery logs.

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -11,7 +11,7 @@ applications:
 
     processes:
     - type: web
-      command: celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=1
+      command: celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=1 2> /dev/null
       health-check-type: process
       memory: 2G
 


### PR DESCRIPTION
Directing the celery logs to dev/null, we already have the logs going to logit using the backing service. If we don't ignore these logs, we end up with a lot of extra noise in the logs, making support difficult.