### PR TITLE
Improve ftp app performance

### DIFF
--- a/app/sftp/ftp_client.py
+++ b/app/sftp/ftp_client.py
@@ -62,6 +62,7 @@ def upload_zip(sftp, zip_data, filename, statsd_client):
 
     with sftp.open('{}/{}'.format(sftp.pwd, filename), mode='w') as remote_file:
         remote_file.set_pipelined()
+        zip_data = memoryview(zip_data.encode())
         remote_file.write(zip_data)
 
     statsd_client.timing("ftp-client.zip-upload-time", monotonic() - start_time)

--- a/app/sftp/ftp_client.py
+++ b/app/sftp/ftp_client.py
@@ -61,6 +61,7 @@ def upload_zip(sftp, zip_data, filename, statsd_client):
             ))
 
     with sftp.open('{}/{}'.format(sftp.pwd, filename), mode='w') as remote_file:
+        remote_file.set_pipelined()
         remote_file.write(zip_data)
 
     statsd_client.timing("ftp-client.zip-upload-time", monotonic() - start_time)


### PR DESCRIPTION
## What
Use pipelining and memoryview to improve performance.

## How to review

Commit by commit and look at the table below

## More details

Using [line-profiler] I started looking for any bottlenecks in our code and understand why we see such huge difference between our code and the command line `sftp`.

The first finding was that it was spending a significant part of the time waiting to hear back from the server, for every packet we sent. Enabling [pipeline] fixed that, and gave us a significant boost, although still much slower than `sftp`.

Then I noticed a weird behaviour where the data rate would pick up as we were approaching the end of the file. For a 100MB file, it would maintain a rate of ~2MB/s until it had transferred ~70MB and then the rate would increase to ~10MB/s.

@leohemsted found the problem at [this line] where it is slicing off the first `count` bytes, but ends up [copying] the array on every  loop. To get around this, we converted our data to [`memoryview`] objects which improved the performance to levels comparable to the `sftp` cli. For more details on memoryview objects and the underlying BufferProtocol take a look at this blog post: 

https://julien.danjou.info/high-performance-in-python-with-zero-copy-and-the-buffer-protocol/

Below is a table for the time it took to copy files of different sizes and the impact of each change:

File size| No optimisation | `set_pipelined` only | `memoryview` only | both
------------ | --------------------| --------------|------------------|---------|
100MB | ~254s | 78.1s | 152s | 3.4s
40MB | ~68s | 7.1s | 60s | 1.3s
5MB | ~7s | 0.2s | 6.8s | 0.15s

[line-profiler]: https://pypi.org/project/line-profiler/
[this line]:  https://github.com/paramiko/paramiko/blob/5cf145ffd3d7cd4d96a511376267a7f27cce5eed/paramiko/file.py#L523
[pipeline]: https://paramiko-docs.readthedocs.io/en/latest/api/sftp.html#paramiko.sftp_file.SFTPFile.set_pipelined
[copying]: https://stackoverflow.com/questions/5722006/does-python-do-slice-by-reference-on-strings
[`memoryview`]: https://docs.python.org/3/c-api/memoryview.html

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)