### PR TITLE
S3 download improvement

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,79 @@
+queues.csv
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+venv/
+venv-freeze/
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+/cache
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+.pytest_cache
+coverage.xml
+test_results.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+.idea/
+.vscode
+
+# Mac
+*.DS_Store
+environment.sh
+.envrc
+
+celerybeat-schedule
+
+# CloudFoundry
+.cf
+
+/scripts/run_my_tests.sh
+

--- a/app/config.py
+++ b/app/config.py
@@ -38,7 +38,7 @@ class Config(object):
         # restart workers after each task is executed - this will help prevent any memory leaks (not that we should be
         # encouraging sloppy memory management). Since we only run a handful of tasks per day, and none are time
         # sensitive, the extra couple of seconds overhead isn't seen to be a huge issue.
-        'worker_max_tasks_per_child': 1
+        'worker_max_tasks_per_child': 20
     }
 
     STATSD_ENABLED = False

--- a/tests/app/file_utils/test_file_utils.py
+++ b/tests/app/file_utils/test_file_utils.py
@@ -43,8 +43,8 @@ def test_get_zip_of_letter_pdfs_from_s3(notify_ftp, mocker):
 
     zipfile = ZipFile(BytesIO(zip_data))
 
-    assert zipfile.namelist()[0] == 'TEST1.PDF'
-    assert zipfile.namelist()[1] == 'TEST2.PDF'
+    assert 'TEST1.PDF' in zipfile.namelist()
+    assert 'TEST2.PDF' in zipfile.namelist()
     assert zipfile.read('TEST1.PDF') == b'\x00\x01'
     assert zipfile.read('TEST2.PDF') == b'\x00\x01'
 


### PR DESCRIPTION
This is in order to further improve performance of the FTP application.

Specifically we found that the `get_zip_of_letter_pdfs_from_s3` function
was responsible for the 33 of the 37 seconds of the total task duration.

This commit is using the python 3 feature that allows us to launch tasks
in parallel, using the ThreadPoolExecutor:

https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Future

This almost halves the time taken to retrieve files from S3 from 33 seconds to an average of 18.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)