### PR TITLE
Pin cryptography to a version < 3.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 pysftp==0.2.9
 Flask==1.1.2
 awscli-cwlogs>=1.4,<1.5
+cryptography<3.4
 # nb: when bumping this, check to see if celery sqs deps have bumped here: https://github.com/celery/celery/blob/master/requirements/extras/sqs.txt
 # celery[sqs] pins pycurl to an old version so we are just installing sqs deps ourselves.
 celery==4.4.1


### PR DESCRIPTION
One of our dependencies has a dependency on cryptography, which has
recently released version 3.4.

This version introduced a circular import error
(https://github.com/pyca/cryptography/issues/5756) which was fixed in
3.4.1.

However, 3.4.1 has a different error where it fails because it cannot
find a rust compiler.

The [suggested
solutions](https://cryptography.io/en/latest/faq.html#installing-cryptography-fails-with-error-can-not-find-rust-compiler) are:

1. Install a newer version of pip which will install a pre-compiled
   cryptography wheel OR
2. Have rust installed and available on our PATH so that it can be used
   to build the package.

Since we can't change the buildpack's pip version and we cannot install
rust ourselves, the only we're left with is to avoid upgrading to 3.4 -
at least until PaaS updates their python buildpacks.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)