### PR TITLE
Actually turn on StatsD for this repo

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -41,9 +41,9 @@ class Config(object):
         'worker_max_tasks_per_child': 20
     }
 
-    STATSD_ENABLED = False
-    STATSD_HOST = "statsd.hostedgraphite.com"
+    STATSD_HOST = os.getenv('STATSD_HOST')
     STATSD_PORT = 8125
+    STATSD_ENABLED = bool(STATSD_HOST)
 
     LOCAL_FILE_STORAGE_PATH = "~/dvla-file-storage"
 
@@ -70,7 +70,6 @@ class Development(Config):
 
 
 class Test(Development):
-    STATSD_ENABLED = False
     LOCAL_FILE_STORAGE_PATH = "/tmp/dvla-file-storage"
 
     DVLA_JOB_BUCKET_NAME = 'test-dvla-file-per-job'
@@ -80,7 +79,6 @@ class Test(Development):
 
 
 class Preview(Config):
-
     DVLA_JOB_BUCKET_NAME = 'preview-dvla-file-per-job'
     DVLA_API_BUCKET_NAME = 'preview-dvla-letter-api-files'
 
@@ -88,8 +86,6 @@ class Preview(Config):
 
 
 class Staging(Config):
-    STATSD_ENABLED = False
-
     DVLA_JOB_BUCKET_NAME = 'staging-dvla-file-per-job'
     DVLA_API_BUCKET_NAME = 'staging-dvla-letter-api-files'
 
@@ -97,8 +93,6 @@ class Staging(Config):
 
 
 class Production(Config):
-    STATSD_ENABLED = False
-
     DVLA_JOB_BUCKET_NAME = 'production-dvla-file-per-job'
     DVLA_API_BUCKET_NAME = 'production-dvla-letter-api-files'
 

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -38,6 +38,7 @@ applications:
       NOTIFY_ENVIRONMENT: '{{ NOTIFY_ENVIRONMENT }}'
       NOTIFY_LOG_PATH: '/home/vcap/logs/app.log'
 
+      STATSD_HOST: "notify-statsd-exporter-{{ environment }}.apps.internal"
 
       AWS_ACCESS_KEY_ID: '{{ AWS_ACCESS_KEY_ID }}'
       AWS_SECRET_ACCESS_KEY: '{{ AWS_SECRET_ACCESS_KEY }}'


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/176261229

This mirrors the config we have in the API [1][2].

[1]: https://github.com/alphagov/notifications-api/blob/38af26cc784e63e6830b45c1bdfe9e8b72722e19/app/config.py#L330-L332
[2]: https://github.com/alphagov/notifications-api/blob/38af26cc784e63e6830b45c1bdfe9e8b72722e19/manifest.yml.j2#L132




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)