### PR TITLE
Fix broken deploy due to cryptography upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,15 @@
 pysftp==0.2.9
 Flask==1.1.2
 awscli-cwlogs>=1.4,<1.5
-# nb: when bumping this, check to see if celery sqs deps have bumped here: https://github.com/celery/celery/blob/master/requirements/extras/sqs.txt
-# celery[sqs] pins pycurl to an old version so we are just installing sqs deps ourselves.
-celery==5.0.5
 pycurl==7.43.0.6
 boto3==1.17.54  # pin to minor version as patch versions update very frequently
 
 # higher version causes build to fail on PaaS due to lack of Rust
 # see https://github.com/pyca/cryptography/issues/5810
 cryptography==3.3.2 # pyup: <3.4
+
+# nb: when bumping this, check to see if celery sqs deps have bumped here: https://github.com/celery/celery/blob/master/requirements/extras/sqs.txt
+# celery[sqs] pins pycurl to an old version so we are just installing sqs deps ourselves.
+celery==5.0.5
 
 git+https://github.com/alphagov/notifications-utils.git@43.5.4#egg=notifications-utils==43.5.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,14 @@
 pysftp==0.2.9
 Flask==1.1.2
 awscli-cwlogs>=1.4,<1.5
-cryptography==3.4.7
 # nb: when bumping this, check to see if celery sqs deps have bumped here: https://github.com/celery/celery/blob/master/requirements/extras/sqs.txt
 # celery[sqs] pins pycurl to an old version so we are just installing sqs deps ourselves.
 celery==5.0.5
 pycurl==7.43.0.6
 boto3==1.17.54  # pin to minor version as patch versions update very frequently
+
+# higher version causes build to fail on PaaS due to lack of Rust
+# see https://github.com/pyca/cryptography/issues/5810
+cryptography==3.3.2 # pyup: <3.4
 
 git+https://github.com/alphagov/notifications-utils.git@43.5.4#egg=notifications-utils==43.5.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pysftp==0.2.9
 Flask==1.1.2
 awscli-cwlogs>=1.4,<1.5
 pycurl==7.43.0.6
-boto3==1.17.54  # pin to minor version as patch versions update very frequently
+boto3==1.17.54
 
 # higher version causes build to fail on PaaS due to lack of Rust
 # see https://github.com/pyca/cryptography/issues/5810


### PR DESCRIPTION
Please see the commit messages for more details.




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)