### PR TITLE
Use pip instead of pip3 in boostrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ CF_MANIFEST_PATH ?= /tmp/manifest.yml
 bootstrap: ## Install dependencies, etc.
 	echo "Checking pycurl version. Check ./README.md for installation steps."
 	python -c "import pycurl; print(pycurl.version)" | grep -i openssl
-	pip3 install -r requirements_for_test.txt
+	pip install -r requirements_for_test.txt
 
 .PHONY: run-celery
 run-celery: ## Runs celery worker


### PR DESCRIPTION
This is consistent with our other repos.




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)