### PR TITLE
Freeze version of click because version 8.0 conflicts with celery 5.0.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ Flask==1.1.2
 awscli-cwlogs>=1.4,<1.5
 pycurl==7.43.0.6
 boto3==1.17.63
+click<8.0,>=7.0
 
 # higher version causes build to fail on PaaS due to lack of Rust
 # see https://github.com/pyca/cryptography/issues/5810


### PR DESCRIPTION

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)