### PR TITLE
Revert "Revert "Add a retry for the zip_and_send_letter_pdfs task.""

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ target/
 
 # IDEs
 .vscode
+.idea/


### PR DESCRIPTION
This was reverted this morning but it turns out this was not the problem. 
The dependency conflicts have been resolved. This is okay to go in again.
---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)