### PR TITLE
Remove pycurl check in bootstrap task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,6 @@ CF_MANIFEST_PATH ?= /tmp/manifest.yml
 
 .PHONY: bootstrap
 bootstrap: ## Install dependencies, etc.
-	echo "Checking pycurl version. Check ./README.md for installation steps."
-	python -c "import pycurl; print(pycurl.version)" | grep -i openssl
 	pip install -r requirements_for_test.txt
 
 .PHONY: run-celery


### PR DESCRIPTION
This causes the task to fail on CI (where we're looking to use it
instead of CI having its own setup [1]).

The README has extensive guidance on installing pycurl for local
development, so I think it's OK to remove the check here. I can't
find any specific pycurl setup for CI, which also raises a question
of whether it's actually necessary - maybe it's just a Mac v. Linux
issue, so no additional setup is required on CI.




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)