### PR TITLE
Update NOTIFY_APP_NAME

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -18,7 +18,7 @@ class Config(object):
     # Default config values ###
     ###########################
 
-    NOTIFY_APP_NAME = 'api'
+    NOTIFY_APP_NAME = 'ftp'
     AWS_REGION = os.getenv('AWS_REGION', 'eu-west-1')
     NOTIFY_LOG_PATH = os.getenv('NOTIFY_LOG_PATH', '/var/log/notify/application.log')
 

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -26,7 +26,7 @@ applications:
         memory: 64M
 
     env:
-      NOTIFY_APP_NAME: notify-ftp
+      NOTIFY_APP_NAME: ftp
       LOGGING_STDOUT_JSON: '1'
 
       # Credentials variables


### PR DESCRIPTION
This was wrongly set to `api` instead of `ftp`



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)