### PR TITLE
Remove StatsD timer where we ignore the data

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -21,6 +21,6 @@ def create_app(application):
     statsd_client.init_app(application)
     logging.init_app(application, statsd_client)
     notify_celery.init_app(application)
-    ftp_client.init_app(application, statsd_client)
+    ftp_client.init_app(application)
 
     return application

--- a/app/sftp/ftp_client.py
+++ b/app/sftp/ftp_client.py
@@ -12,11 +12,10 @@ class FtpException(Exception):
 
 
 class FtpClient():
-    def init_app(self, app, statsd_client):
+    def init_app(self, app):
         self.host = app.config.get('FTP_HOST')
         self.username = app.config.get('FTP_USERNAME')
         self.password = app.config.get('FTP_PASSWORD')
-        self.statsd_client = statsd_client
 
     @contextmanager
     def _sftp(self):
@@ -33,14 +32,14 @@ class FtpClient():
 
     def send_zip(self, zip_data, filename):
         with self._sftp() as sftp:
-            upload_zip(sftp, zip_data, filename, self.statsd_client)
+            upload_zip(sftp, zip_data, filename)
 
     def file_exists_with_correct_size(self, filename, zip_data_len):
         with self._sftp() as sftp:
             check_file_exist_and_is_right_size(sftp, filename, zip_data_len)
 
 
-def upload_zip(sftp, zip_data, filename, statsd_client):
+def upload_zip(sftp, zip_data, filename):
     sftp.chdir(NOTIFY_SUBFOLDER)
     zip_data_len = len(zip_data)
 
@@ -71,8 +70,6 @@ def upload_zip(sftp, zip_data, filename, statsd_client):
 
     current_app.logger.info("uploaded file {} of total size {} bytes in {} seconds".format(
         filename, zip_data_len, upload_duration))
-
-    statsd_client.timing("ftp-client.zip-upload-time", upload_duration)
 
     check_file_exist_and_is_right_size(sftp, filename, zip_data_len)
 

--- a/tests/app/sftp/test_ftp_client.py
+++ b/tests/app/sftp/test_ftp_client.py
@@ -31,7 +31,7 @@ def test_upload_zip_success(mocks):
         lstat=Mock(return_value=mocks.mock_lstat),
     )
 
-    upload_zip(mock_zip_sftp, mocks.mock_data, mocks.mock_remote_filename, Mock())
+    upload_zip(mock_zip_sftp, mocks.mock_data, mocks.mock_remote_filename)
 
     mock_zip_sftp.chdir.assert_called_once_with('notify')
     mock_zip_sftp.open.assert_called_once_with('~/notify/' + mocks.mock_remote_filename, mode='w')
@@ -49,7 +49,7 @@ def test_send_zip_doesnt_overwrite_if_file_exists_with_same_size(mocks):
         lstat=Mock(return_value=mocks.mock_lstat),
     )
 
-    upload_zip(mock_zip_sftp, mocks.mock_data, mocks.mock_remote_filename, Mock())
+    upload_zip(mock_zip_sftp, mocks.mock_data, mocks.mock_remote_filename)
 
     assert mock_zip_sftp.open.called is False
 
@@ -65,7 +65,7 @@ def test_send_zip_overwrites_if_file_exists_with_different_size(mocks):
         lstat=Mock(side_effect=[mocks.mock_bad_lstat, mocks.mock_lstat]),
     )
 
-    upload_zip(mock_zip_sftp, mocks.mock_data, mocks.mock_remote_filename, Mock())
+    upload_zip(mock_zip_sftp, mocks.mock_data, mocks.mock_remote_filename)
 
     mock_zip_sftp.open.assert_called_once_with('~/notify/' + mocks.mock_remote_filename, mode='w')
 
@@ -80,7 +80,7 @@ def test_send_zip_errors_if_file_wasnt_put_on(mocks):
     )
 
     with pytest.raises(FtpException):
-        upload_zip(mock_zip_sftp, mocks.mock_data, mocks.mock_remote_filename, Mock())
+        upload_zip(mock_zip_sftp, mocks.mock_data, mocks.mock_remote_filename)
 
 
 @freeze_time('2016-01-01T17:00:00')
@@ -94,7 +94,7 @@ def test_send_zip_errors_if_remote_file_size_is_different(mocks):
     )
 
     with pytest.raises(FtpException):
-        upload_zip(mock_zip_sftp, mocks.mock_data, mocks.mock_remote_filename, Mock())
+        upload_zip(mock_zip_sftp, mocks.mock_data, mocks.mock_remote_filename)
 
 
 def test_file_exists_with_correct_size(mocks):


### PR DESCRIPTION
There's no mapping for this so the data is being dropped [1]. We
still have the logs and can use CloudWatch to parse and analyse
the times if need be.

[1]: https://github.com/alphagov/notifications-aws/blob/master/paas/statsd/statsd-mapping.yml




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)