### PR TITLE
Bump utils to bring in latest NotifyCelery code

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -13,4 +13,4 @@ cryptography==3.3.2 # pyup: <3.4
 # celery[sqs] pins pycurl to an old version so we are just installing sqs deps ourselves.
 celery==5.0.5
 
-git+https://github.com/alphagov/notifications-utils.git@48.1.0#egg=notifications-utils==48.1.0
+git+https://github.com/alphagov/notifications-utils.git@49.0.0#egg=notifications-utils==49.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,9 @@ cachetools==4.2.2
 celery==5.0.5
     # via -r requirements.in
 certifi==2020.12.5
-    # via requests
+    # via
+    #   pyproj
+    #   requests
 cffi==1.14.5
     # via
     #   bcrypt
@@ -93,7 +95,7 @@ markupsafe==2.0.1
     # via jinja2
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@48.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@49.0.0
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils
@@ -116,6 +118,8 @@ pynacl==1.4.0
 pyparsing==2.4.7
     # via packaging
 pypdf2==1.26.0
+    # via notifications-utils
+pyproj==3.2.1
     # via notifications-utils
 pysftp==0.2.9
     # via -r requirements.in


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180213914

The new version of the base class:

- Reenables Celery argument checking
- Removes redundant code

See here for more details [1]. This also brings in an additional
but irrelevant change, relating to broadcast polygons.

[1]: https://github.com/alphagov/notifications-utils/pull/921




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)