### PR TITLE
Bump utils to 51.3.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -13,4 +13,4 @@ cryptography==3.3.2 # pyup: <3.4
 # celery[sqs] pins pycurl to an old version so we are just installing sqs deps ourselves.
 celery==5.0.5
 
-git+https://github.com/alphagov/notifications-utils.git@49.0.0#egg=notifications-utils==49.0.0
+git+https://github.com/alphagov/notifications-utils.git@51.3.0#egg=notifications-utils==51.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -95,7 +95,7 @@ markupsafe==2.0.1
     # via jinja2
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@49.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@51.3.0
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180693991

This app has nothing to do with broadcasts or CSVs - this upgrade
is to pull in new logging for the NotifyCelery base class [1].

[1]: https://github.com/alphagov/notifications-utils/blob/master/CHANGELOG.md#5130




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)