### PR TITLE
Centralise documentation for updating dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,6 @@ Although this app includes Flask, it's not possible to run `flask shell`. Run th
 make shell
 ```
 
-## To update application dependencies
+## Further documentation
 
-`requirements.txt` is generated from the `requirements.in` in order to pin versions of all nested dependencies. If `requirements.in` has been changed, run `make freeze-requirements` to regenerate it.
+- [Updating dependencies](https://github.com/alphagov/notifications-manuals/wiki/Dependencies)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180760212

This follows the convention established in [1].

[1]: https://github.com/alphagov/notifications-antivirus/pull/83




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)