### PR TITLE
Unpin version of cryptography package

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -5,10 +5,6 @@ pycurl==7.43.0.6
 boto3==1.17.63
 click<8.0,>=7.0
 
-# higher version causes build to fail on PaaS due to lack of Rust
-# see https://github.com/pyca/cryptography/issues/5810
-cryptography==3.3.2 # pyup: <3.4
-
 # nb: when bumping this, check to see if celery sqs deps have bumped here: https://github.com/celery/celery/blob/master/requirements/extras/sqs.txt
 # celery[sqs] pins pycurl to an old version so we are just installing sqs deps ourselves.
 celery==5.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,9 +59,7 @@ click-repl==0.1.6
 colorama==0.4.3
     # via awscli
 cryptography==3.3.2
-    # via
-    #   -r requirements.in
-    #   paramiko
+    # via paramiko
 docutils==0.15.2
     # via awscli
 flask==1.1.2


### PR DESCRIPTION
This follows the same approach as [1].

[1]: https://github.com/alphagov/notifications-admin/pull/4138




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)