### PR TITLE
Ftp timeouts

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -1,6 +1,7 @@
 import json
 
 from botocore.exceptions import ClientError
+from celery.exceptions import SoftTimeLimitExceeded
 from flask import current_app
 from notifications_utils.s3 import s3upload as utils_s3upload
 
@@ -24,7 +25,14 @@ def get_error_task_name_or_retry(task, upload_filename):
         return "update-letter-notifications-to-error"
 
 
-@notify_celery.task(bind=True, name="zip-and-send-letter-pdfs", max_retries=5, default_retry_delay=300)
+@notify_celery.task(
+    bind=True,
+    name="zip-and-send-letter-pdfs",
+    max_retries=5,
+    default_retry_delay=300,
+    # after 90 seconds celery will raise a SoftTimeLimitExceeded exception
+    soft_time_limit=90
+)
 def zip_and_send_letter_pdfs(self, filenames_to_zip, upload_filename):
     folder_date = filenames_to_zip[0].split('/')[0]
     zips_sent_filename = '{}/zips_sent/{}.TXT'.format(folder_date, upload_filename)
@@ -54,6 +62,9 @@ def zip_and_send_letter_pdfs(self, filenames_to_zip, upload_filename):
     except ClientError:
         current_app.logger.exception(
             f'FTP app failed to download PDF from S3 bucket {folder_date} for zip file: {upload_filename}')
+        task_name = get_error_task_name_or_retry(self, upload_filename)
+    except SoftTimeLimitExceeded:
+        current_app.logger.exception(f'FTP app timed out sending zip file: {upload_filename}')
         task_name = get_error_task_name_or_retry(self, upload_filename)
     except FtpException:
         try:

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -15,6 +15,15 @@ from app.sftp.ftp_client import FtpException
 NOTIFY_QUEUE = 'notify-internal-tasks'
 
 
+def get_error_task_name_or_retry(task, upload_filename):
+    try:
+        task.retry(queue='process-ftp-tasks')
+    except task.MaxRetriesExceededError:
+        current_app.logger.exception(
+            f'Max retry failed: FTP app failed to send letters for zip file: {upload_filename}')
+        return "update-letter-notifications-to-error"
+
+
 @notify_celery.task(bind=True, name="zip-and-send-letter-pdfs", max_retries=5, default_retry_delay=300)
 def zip_and_send_letter_pdfs(self, filenames_to_zip, upload_filename):
     folder_date = filenames_to_zip[0].split('/')[0]
@@ -45,8 +54,7 @@ def zip_and_send_letter_pdfs(self, filenames_to_zip, upload_filename):
     except ClientError:
         current_app.logger.exception(
             f'FTP app failed to download PDF from S3 bucket {folder_date} for zip file: {upload_filename}')
-        self.retry(queue='process-ftp-tasks')
-        return
+        task_name = get_error_task_name_or_retry(self, upload_filename)
     except FtpException:
         try:
             # check if file exists with the right size.
@@ -55,12 +63,7 @@ def zip_and_send_letter_pdfs(self, filenames_to_zip, upload_filename):
             task_name = "update-letter-notifications-to-sent"
         except FtpException:
             current_app.logger.exception(f'FTP app failed to send letters for zip file: {upload_filename}')
-            self.retry(queue='process-ftp-tasks')
-            return
-    except self.MaxRetriesExceededError:
-        current_app.logger.exception(
-            f'Max retry failed: FTP app failed to send letters for zip file: {upload_filename}')
-        task_name = "update-letter-notifications-to-error"
+            task_name = get_error_task_name_or_retry(self, upload_filename)
     else:
         task_name = "update-letter-notifications-to-sent"
 

--- a/app/sftp/ftp_client.py
+++ b/app/sftp/ftp_client.py
@@ -24,6 +24,7 @@ class FtpClient():
             cnopts.hostkeys = None
             current_app.logger.info("opening connection to {}".format(self.host))
             with pysftp.Connection(self.host, username=self.username, password=self.password, cnopts=cnopts) as sftp:
+                sftp.timeout = 30
                 yield sftp
         except Exception as e:
             # reraise all exceptions as FtpException to ensure we can handle them down the line

--- a/tests/app/celery/test_zip_and_send_letter_pdfs.py
+++ b/tests/app/celery/test_zip_and_send_letter_pdfs.py
@@ -94,24 +94,21 @@ def test_zip_and_send_should_retry_if_s3_client_error(mocks):
     with pytest.raises(Retry):
         zip_and_send_letter_pdfs(filenames, 'foo.zip')
 
-        mocks.zip_and_send_retry.assert_called_once_with(
-            filenames_to_zip=filenames,
-            upload_filename='foo.zip',
-            queue='process-ftp-tasks'
-        )
+    mocks.zip_and_send_retry.assert_called_once_with(queue='process-ftp-tasks')
 
 
 def test_zip_and_send_should_update_notification_if_max_retries_when_s3_client_error(mocks):
     mocks.get_zip_of_letter_pdfs_from_s3.side_effect = ClientError({}, 'operation')
     mocks.zip_and_send_retry.side_effect = MaxRetriesExceededError
     filenames = ['2017-01-01/TEST1.PDF']
-    with pytest.raises(MaxRetriesExceededError):
-        zip_and_send_letter_pdfs(filenames, 'foo.zip')
-        mocks.send_task.assert_called_once_with(
-            name='update-letter-notifications-to-error',
-            args=(['1', '2', '3'],),
-            queue='notify-internal-tasks'
-        )
+
+    zip_and_send_letter_pdfs(filenames, 'foo.zip')
+
+    mocks.send_task.assert_called_once_with(
+        name='update-letter-notifications-to-error',
+        args=(['1', '2', '3'],),
+        queue='notify-internal-tasks'
+    )
 
 
 def test_zip_and_send_should_retry_if_send_zip_fails_and_files_did_not_upload(mocks):
@@ -121,13 +118,10 @@ def test_zip_and_send_should_retry_if_send_zip_fails_and_files_did_not_upload(mo
     filenames = ['2017-01-01/TEST1.PDF']
     with pytest.raises(Retry):
         zip_and_send_letter_pdfs(filenames, 'foo.zip')
-        mocks.file_exists_with_correct_size.assert_called_once_with('foo.zip', 2)
-        mocks.zip_and_send_retry.assert_called_once_with(
-            filenames_to_zip=filenames,
-            upload_filename='foo.zip',
-            queue='process-ftp-tasks'
-        )
-        assert not mocks.send_task.called
+
+    mocks.file_exists_with_correct_size.assert_called_once_with('foo.zip', 2)
+    mocks.zip_and_send_retry.assert_called_once_with(queue='process-ftp-tasks')
+    assert not mocks.send_task.called
 
 
 def test_zip_and_send_should_set_to_error_after_max_retries_after_files_did_not_upload(mocks):
@@ -136,14 +130,15 @@ def test_zip_and_send_should_set_to_error_after_max_retries_after_files_did_not_
     mocks.zip_and_send_retry.side_effect = MaxRetriesExceededError
 
     filenames = ['2017-01-01/TEST1.PDF']
-    with pytest.raises(MaxRetriesExceededError):
-        zip_and_send_letter_pdfs(filenames, 'foo.zip')
-        mocks.file_exists_with_correct_size.assert_called_once_with('foo.zip', 2)
-        mocks.send_task.assert_called_once_with(
-            name='update-letter-notifications-to-error',
-            args=(['1', '2', '3'],),
-            queue='notify-internal-tasks'
-        )
+
+    zip_and_send_letter_pdfs(filenames, 'foo.zip')
+
+    mocks.file_exists_with_correct_size.assert_called_once_with('foo.zip', 2)
+    mocks.send_task.assert_called_once_with(
+        name='update-letter-notifications-to-error',
+        args=(['1', '2', '3'],),
+        queue='notify-internal-tasks'
+    )
 
 
 def test_zip_and_send_should_update_notifications_to_success_if_send_zip_fails_but_files_uploaded(mocks):
@@ -199,11 +194,8 @@ def test_zip_and_send_should_retry_if_cant_check_zips_sent(mocks):
     filenames = ['2017-01-01/TEST1.PDF']
     with pytest.raises(Retry):
         zip_and_send_letter_pdfs(filenames, 'foo.zip')
-        mocks.zip_and_send_retry.assert_called_once_with(
-            filenames_to_zip=filenames,
-            upload_filename='foo.zip',
-            queue='process-ftp-tasks'
-        )
+
+    mocks.zip_and_send_retry.assert_called_once_with(queue='process-ftp-tasks')
 
 
 def test_zip_and_send_should_set_to_error_after_max_retries_if_cant_check_zips_sent(mocks):
@@ -211,11 +203,11 @@ def test_zip_and_send_should_set_to_error_after_max_retries_if_cant_check_zips_s
     mocks.zip_and_send_retry.side_effect = MaxRetriesExceededError
 
     filenames = ['2017-01-01/TEST1.PDF']
-    with pytest.raises(MaxRetriesExceededError):
-        zip_and_send_letter_pdfs(filenames, 'foo.zip')
 
-        mocks.send_task.assert_called_once_with(
-            name='update-letter-notifications-to-error',
-            args=(['1', '2', '3'],),
-            queue='notify-internal-tasks'
-        )
+    zip_and_send_letter_pdfs(filenames, 'foo.zip')
+
+    mocks.send_task.assert_called_once_with(
+        name='update-letter-notifications-to-error',
+        args=(['1', '2', '3'],),
+        queue='notify-internal-tasks'
+    )

--- a/tests/app/sftp/test_ftp_client.py
+++ b/tests/app/sftp/test_ftp_client.py
@@ -122,7 +122,8 @@ def test_file_exists_with_correct_size_throws_exception_when_file_does_not_exist
 
     with pytest.raises(expected_exception=FtpException) as e:
         check_file_exist_and_is_right_size(mock_sftp, remote_filename, len(zip_data))
-        assert e.value == "Zip file {} not uploaded".format(remote_filename)
+
+    assert str(e.value) == "Zip file file_does_not_exist_remotely.zip not uploaded"
     mock_sftp.listdir.assert_called_once_with()
 
 
@@ -133,11 +134,14 @@ def test_file_exists_with_correct_size_throws_exception_file_exists_with_wrong_s
         pwd='~/notify',
         exists=Mock(return_value=False),
         listdir=Mock(return_value=[remote_filename]),
-        lstat=Mock(st_size=1)
+        lstat=Mock(return_value=Mock(st_size=1))
     )
 
     with pytest.raises(expected_exception=FtpException) as e:
         check_file_exist_and_is_right_size(mock_sftp, remote_filename, len(zip_data))
-        assert e.value == "Zip file {} uploaded but size is incorrect: is {}, expected {}d".format(
-            remote_filename, len(zip_data), 1)
-    mock_sftp.lstat.assert_called_once_with('~/notify/{}'.format(remote_filename))
+
+    assert str(e.value) == (
+        "Zip file file_does_not_exist_remotely.zip uploaded but size is incorrect: "
+        "is 1, expected 9"
+    )
+    mock_sftp.lstat.assert_called_once_with('~/notify/file_does_not_exist_remotely.zip')


### PR DESCRIPTION
Best reviewed commit-by-commit.

* Fix tests that never asserted because the asserts were inside pytest.raises blocks
* Fix the code that never worked and we didn't realise because the tests didn't work
* Add a timeout at the celery level
* Add a timeout at the SFTP level for good measure

I set the entire task timeout to 90 seconds and the sftp timeout to 30 seconds, which was a totally arbitrary decision that I am in no way wedded to. I'm open to ideas. Normally tasks take up to 20 seconds.

[I still need to thoroughly test this manually but obviously that's a little tricky.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)