### PR TITLE
Document ongoing issue with local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,11 @@ Celery app that sends letters from GOV.UK Notify to DVLA over FTP
 
 ## Setting Up
 
+**Running the app locally is currently broken on some machines, so you can skip all of the following steps. See https://github.com/alphagov/notifications-ftp/issues/367**
+
 ### AWS credentials
 
 To run the API you will need appropriate AWS credentials. See the [Wiki](https://github.com/alphagov/notifications-manuals/wiki/aws-accounts#how-to-set-up-local-development) for more details.
-
-### pycurl
-
-See https://github.com/alphagov/notifications-manuals/wiki/Getting-started#pycurl
 
 ### `environment.sh`
 
@@ -63,6 +61,8 @@ make bootstrap
 
 make run-celery
 ```
+
+**This is currently broken on some machines. See https://github.com/alphagov/notifications-ftp/issues/367**
 
 ##  To test the application
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181498273

We've agreed we're not going to fix this anytime soon because we
don't often need to run this app locally. The issue for this may
not be obvious to someone getting started, so I think it's worth
linking to it explicitly in the README.

I've also removed the guidance for pycurl:

- There's little evidence it works at all.
- It's not necessary to run the tests.
- It won't be necessary for a Dockerised app.




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)