### PR TITLE
Fix pip install failing on Mac M1 machines

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -58,7 +58,7 @@ click-repl==0.1.6
     # via celery
 colorama==0.4.3
     # via awscli
-cryptography==3.3.2
+cryptography==3.4.8
     # via paramiko
 docutils==0.15.2
     # via awscli
@@ -156,7 +156,6 @@ six==1.16.0
     #   bcrypt
     #   bleach
     #   click-repl
-    #   cryptography
     #   govuk-bank-holidays
     #   pynacl
     #   python-dateutil

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -6,3 +6,4 @@ moto==2.0.6
 pytest-env==0.6.2
 pytest-mock==3.6.0
 pytest==6.2.3
+jinja2-cli[yaml]


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181498273

Fixes this error:

        build/temp.macosx-12.2-arm64-3.9/_openssl.c:575:10: fatal error: 'openssl/opensslv.h' file not found
        #include <openssl/opensslv.h>
                 ^~~~~~~~~~~~~~~~~~~~

I did consider upgrading to the latest version, but since this is
a low-level dependency I think we should wait for the libraries
that depend on it to give the signal first.

Version 3.4+ introduce Rust into the build pipeline [^1], which I
recall we had problems with previously, but a test deploy indicates
there's nothing to worry about here.

I've also added jinja2-cli to support local deployments - in order
to generate the manifest file.

[^1]: https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#34---2021-02-07




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)