### PR TITLE
Bump utils to 55.1.4

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -2,11 +2,10 @@ pysftp==0.2.9
 Flask==2.0.3
 awscli-cwlogs>=1.4,<1.5
 pycurl==7.43.0.6
-boto3==1.17.63
 click<8.0,>=7.0
 
 # nb: when bumping this, check to see if celery sqs deps have bumped here: https://github.com/celery/celery/blob/master/requirements/extras/sqs.txt
 # celery[sqs] pins pycurl to an old version so we are just installing sqs deps ourselves.
 celery==5.0.5
 
-git+https://github.com/alphagov/notifications-utils.git@55.1.2#egg=notifications-utils==55.1.2
+git+https://github.com/alphagov/notifications-utils.git@55.1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,10 +6,8 @@
 #
 amqp==5.1.0
     # via kombu
-awscli==1.19.80
-    # via
-    #   awscli-cwlogs
-    #   notifications-utils
+awscli==1.22.93
+    # via awscli-cwlogs
 awscli-cwlogs==1.4.6
     # via -r requirements.in
 bcrypt==3.2.0
@@ -18,11 +16,9 @@ billiard==3.6.4.0
     # via celery
 bleach==4.1.0
     # via notifications-utils
-boto3==1.17.63
-    # via
-    #   -r requirements.in
-    #   notifications-utils
-botocore==1.20.80
+boto3==1.21.38
+    # via notifications-utils
+botocore==1.24.38
     # via
     #   awscli
     #   boto3
@@ -93,7 +89,7 @@ markupsafe==2.0.1
     # via jinja2
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.1.2
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.1.4
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils
@@ -144,7 +140,7 @@ requests==2.25.1
     #   notifications-utils
 rsa==4.7.2
     # via awscli
-s3transfer==0.4.2
+s3transfer==0.5.2
     # via
     #   awscli
     #   boto3


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181588331

This required bumping the minimum version of boto3 with:

    pip-compile -P awscli requirements.in

I haven't looked into the awscli/boto3/botocore changes due to the
high churn on those libraries. Given they're minor changes we can
assume they are benign. s3transfer changes are also benign [^1]

This is also a good opportunity to remove the redundant egg spec in
the requirements, like we have in other repos.

[^1]: https://github.com/boto/s3transfer/blob/develop/CHANGELOG.rst




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)