### PR TITLE
Stop injecting NOTIFY_ENVIRONMENT + AWS_REGION

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -19,8 +19,8 @@ class Config(object):
     ###########################
 
     NOTIFY_APP_NAME = 'ftp'
-    AWS_REGION = os.getenv('AWS_REGION', 'eu-west-1')
-    NOTIFY_LOG_PATH = os.getenv('NOTIFY_LOG_PATH', '/var/log/notify/application.log')
+    AWS_REGION = 'eu-west-1'
+    NOTIFY_LOG_PATH = os.getenv('NOTIFY_LOG_PATH')
 
     CELERY = {
         'broker_url': 'sqs://',

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -5,7 +5,7 @@ applications:
     - python_buildpack
 
     routes:
-      - route: notify-ftp-{{ NOTIFY_ENVIRONMENT }}.cloudapps.digital
+      - route: notify-ftp-{{ environment }}.cloudapps.digital
     services:
       - logit-ssl-syslog-drain
 
@@ -35,7 +35,7 @@ applications:
       FTP_PASSWORD: '{{ FTP_PASSWORD }}'
 
       NOTIFICATION_QUEUE_PREFIX: '{{ NOTIFICATION_QUEUE_PREFIX }}'
-      NOTIFY_ENVIRONMENT: '{{ NOTIFY_ENVIRONMENT }}'
+      NOTIFY_ENVIRONMENT: '{{ environment }}'
       NOTIFY_LOG_PATH: '/home/vcap/logs/app.log'
 
       STATSD_HOST: "notify-statsd-exporter-{{ environment }}.apps.internal"


### PR DESCRIPTION
We don't inject these for any other apps and doing so for this one
is confusing and unnecessary indirection.

I've checked they match up with what's currently in -credentials.


---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)