### PR TITLE
Upgrade dependencies

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -7,4 +7,4 @@ pycurl==7.43.0.6
 # celery[sqs] pins pycurl to an old version so we are just installing sqs deps ourselves.
 celery==5.2.6
 
-git+https://github.com/alphagov/notifications-utils.git@55.1.4
+git+https://github.com/alphagov/notifications-utils.git@55.1.6

--- a/requirements.in
+++ b/requirements.in
@@ -2,10 +2,9 @@ pysftp==0.2.9
 Flask==2.0.3
 awscli-cwlogs>=1.4,<1.5
 pycurl==7.43.0.6
-click<8.0,>=7.0
 
 # nb: when bumping this, check to see if celery sqs deps have bumped here: https://github.com/celery/celery/blob/master/requirements/extras/sqs.txt
 # celery[sqs] pins pycurl to an old version so we are just installing sqs deps ourselves.
-celery==5.0.5
+celery==5.2.6
 
 git+https://github.com/alphagov/notifications-utils.git@55.1.4

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 pysftp==0.2.9
-Flask==2.0.3
+Flask==2.1.2
 awscli-cwlogs>=1.4,<1.5
 pycurl==7.43.0.6
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -90,7 +90,7 @@ markupsafe==2.0.1
     # via jinja2
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.1.4
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.1.6
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils
@@ -112,7 +112,7 @@ pynacl==1.4.0
     # via paramiko
 pyparsing==2.4.7
     # via packaging
-pypdf2==1.26.0
+pypdf2==1.27.12
     # via notifications-utils
 pyproj==3.2.1
     # via notifications-utils

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ botocore==1.24.38
     #   s3transfer
 cachetools==4.2.2
     # via notifications-utils
-celery==5.0.5
+celery==5.2.6
     # via -r requirements.in
 certifi==2020.12.5
     # via
@@ -38,9 +38,8 @@ cffi==1.14.5
     #   pynacl
 chardet==4.0.0
     # via requests
-click==7.1.2
+click==8.1.2
     # via
-    #   -r requirements.in
     #   celery
     #   click-didyoumean
     #   click-plugins

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,7 +57,7 @@ cryptography==3.4.8
     # via paramiko
 docutils==0.15.2
     # via awscli
-flask==2.0.3
+flask==2.1.2
     # via
     #   -r requirements.in
     #   flask-redis
@@ -70,6 +70,8 @@ govuk-bank-holidays==0.11
     # via notifications-utils
 idna==2.10
     # via requests
+importlib-metadata==4.11.3
+    # via flask
 itsdangerous==2.0.1
     # via
     #   flask
@@ -172,3 +174,5 @@ webencodings==0.5.1
     # via bleach
 werkzeug==2.0.1
     # via flask
+zipp==3.8.0
+    # via importlib-metadata

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,8 +1,8 @@
 -r requirements.txt
 flake8==4.0.1
 isort==5.10.1
-moto==3.1.4
+moto==3.1.9
 pytest-env==0.6.2
 pytest-mock==3.7.0
-pytest==7.1.1
+pytest==7.1.2
 jinja2-cli[yaml]==0.8.2


### PR DESCRIPTION
Upgrades dependencies and removes `click` as a top level dependency since it no longer needs to be pinned to a specific version (see first commit for details).

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)