### PR TITLE
Generate version file when bootstrapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ target/
 # IDEs
 .vscode
 .idea/
+
+# Files/folders created by build so not present in .cfignore
+app/version.py

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ CF_ORG = "govuk-notify"
 CF_MANIFEST_PATH ?= /tmp/manifest.yml
 
 .PHONY: bootstrap
-bootstrap: ## Install dependencies, etc.
+bootstrap: generate-version-file ## Install dependencies, etc.
 	pip install -r requirements_for_test.txt
 
 .PHONY: run-celery


### PR DESCRIPTION

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)