### PR TITLE
Fix requirements (unable to freeze)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ amqp==5.1.1
     # via kombu
 async-timeout==4.0.2
     # via redis
-awscli==1.25.67
+awscli==1.29.7
     # via awscli-cwlogs
 awscli-cwlogs==1.4.6
     # via -r requirements.in
@@ -20,9 +20,9 @@ bleach==5.0.1
     # via notifications-utils
 blinker==1.6.2
     # via sentry-sdk
-boto3==1.24.66
+boto3==1.28.7
     # via notifications-utils
-botocore==1.27.66
+botocore==1.31.7
     # via
     #   awscli
     #   boto3
@@ -140,7 +140,7 @@ pytz==2022.2.1
     # via
     #   celery
     #   notifications-utils
-pyyaml==5.4.1
+pyyaml==6.0.1
     # via
     #   awscli
     #   notifications-utils
@@ -153,7 +153,7 @@ requests==2.28.1
     #   notifications-utils
 rsa==4.7.2
     # via awscli
-s3transfer==0.6.0
+s3transfer==0.6.1
     # via
     #   awscli
     #   boto3


### PR DESCRIPTION
For the last few days we've been unable to run `make freeze-requirements`, getting errors like this:

```
...
            raise AttributeError(attr)
        AttributeError: cython_sources
        [end of output]

    note: This error originates from a subprocess, and is likely not a problem with pip.
...
pip._internal.exceptions.InstallationSubprocessError: Getting requirements to build wheel exited with 1

make: *** [freeze-requirements] Error 1
```

From some searches online this seems related to a release of cython3 that just came out, which PyYAML uses.

yaml/pyyaml#724

There is now a new release of PyYAML (6.0.1) that fixes the issue, so let's bump to that. In order to bump to that, we need to bump boto3, botocore and s3transfer as well.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)