### PR TITLE
Increase duration for creating and uploading zip

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -30,8 +30,8 @@ def get_error_task_name_or_retry(task, upload_filename):
     name="zip-and-send-letter-pdfs",
     max_retries=5,
     default_retry_delay=300,
-    # after 90 seconds celery will raise a SoftTimeLimitExceeded exception
-    soft_time_limit=90
+    # after 3 minutes celery will raise a SoftTimeLimitExceeded exception
+    soft_time_limit=180
 )
 def zip_and_send_letter_pdfs(self, filenames_to_zip, upload_filename):
     folder_date = filenames_to_zip[0].split('/')[0]


### PR DESCRIPTION
We set a seemingly-arbitrary timeout on this task for processing, zipping and uploading letters to the DVLA FTP. Recently with a large NHS campaign starting we've started to see timeouts on this task.

From https://github.com/alphagov/notifications-ftp/pull/364:

"I set the entire task timeout to 90 seconds and the sftp timeout to 30 seconds, which was a totally arbitrary decision that I am in no way wedded to. I'm open to ideas. Normally tasks take up to 20 seconds."

Let's double it so that it has a bit more time to process letters. I don't think we need to bump sftp timeout because I suspect it's actively doing work, just doesn't have enough time to complete.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)