### PR TITLE
Rollback to cflinuxfs3 due to performance issues

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -9,7 +9,7 @@ applications:
     services:
       - logit-ssl-syslog-drain
 
-    stack: cflinuxfs4
+    stack: cflinuxfs3
 
     processes:
     - type: web


### PR DESCRIPTION
What
----

Rollback to cflinuxfs3

Why
----

Unfortunately we are seeing significant performance issues with cflinuxfs4 in production.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)